### PR TITLE
fix(calendar): Decode calendar id

### DIFF
--- a/lib/tymeslot/integrations/calendar/caldav/xml_handler.ex
+++ b/lib/tymeslot/integrations/calendar/caldav/xml_handler.ex
@@ -88,7 +88,7 @@ defmodule Tymeslot.Integrations.Calendar.CalDAV.XmlHandler do
       |> Enum.filter(fn cal -> cal.is_calendar end)
       |> Enum.map(fn cal ->
         %{
-          id: cal.href,
+          id: URI.decode(cal.href),
           name: determine_calendar_name(cal),
           href: cal.href,
           color: cal.calendar_color,


### PR DESCRIPTION
This is to allow calendars whose path contains special chars (eg @ -> %40) to be associated with a meeting type. Should fix #12 