### PR TITLE
feat(i18n): add Italian translation

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -144,7 +144,8 @@ config :tymeslot, :locales,
     %{code: "en", name: "English", country_code: :gbr},
     %{code: "de", name: "Deutsch", country_code: :deu},
     %{code: "uk", name: "Українська", country_code: :ukr},
-    %{code: "fr", name: "Français", country_code: :fra}
+    %{code: "fr", name: "Français", country_code: :fra},
+    %{code: "it", name: "Italiano", country_code: :ita}
   ],
   default: "en"
 

--- a/lib/tymeslot_web/components/flag_helpers.ex
+++ b/lib/tymeslot_web/components/flag_helpers.ex
@@ -118,6 +118,7 @@ defmodule TymeslotWeb.Components.FlagHelpers do
   defp locale_to_country_code("de"), do: :deu
   defp locale_to_country_code("uk"), do: :ukr
   defp locale_to_country_code("fr"), do: :fra
+  defp locale_to_country_code("it"), do: :ita
   defp locale_to_country_code(_locale), do: nil
 
   @doc """

--- a/lib/tymeslot_web/helpers/locale_format.ex
+++ b/lib/tymeslot_web/helpers/locale_format.ex
@@ -20,6 +20,7 @@ defmodule TymeslotWeb.Helpers.LocaleFormat do
       "de" -> "#{date.day}. #{month_name} #{date.year}"
       "uk" -> "#{date.day} #{month_name} #{date.year}"
       "fr" -> "#{date.day} #{month_name} #{date.year}"
+      "it" -> "#{date.day} #{month_name} #{date.year}"
       _other_locale -> "#{month_name} #{day_padded}, #{date.year}"
     end
   end
@@ -37,6 +38,7 @@ defmodule TymeslotWeb.Helpers.LocaleFormat do
       "de" -> Calendar.strftime(time, "%H:%M")
       "uk" -> Calendar.strftime(time, "%H:%M")
       "fr" -> Calendar.strftime(time, "%H:%M")
+      "it" -> Calendar.strftime(time, "%H:%M")
       _other_locale -> Calendar.strftime(time, "%I:%M %p")
     end
   end
@@ -95,6 +97,22 @@ defmodule TymeslotWeb.Helpers.LocaleFormat do
           "décembre"
         ]
 
+      "it" ->
+        [
+          "gennaio",
+          "febbraio",
+          "marzo",
+          "aprile",
+          "maggio",
+          "giugno",
+          "luglio",
+          "agosto",
+          "settembre",
+          "ottobre",
+          "novembre",
+          "dicembre"
+        ]
+
       _other_locale ->
         [
           "January",
@@ -146,6 +164,15 @@ defmodule TymeslotWeb.Helpers.LocaleFormat do
 
       {"fr", :narrow} ->
         ["D", "L", "M", "M", "J", "V", "S"]
+
+      {"it", :full} ->
+        ["domenica", "lunedì", "martedì", "mercoledì", "giovedì", "venerdì", "sabato"]
+
+      {"it", :short} ->
+        ["dom", "lun", "mar", "mer", "gio", "ven", "sab"]
+
+      {"it", :narrow} ->
+        ["D", "L", "M", "M", "G", "V", "S"]
 
       {_other_locale, :full} ->
         ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
@@ -212,11 +239,13 @@ defmodule TymeslotWeb.Helpers.LocaleFormat do
   end
 
   defp thousand_separator("de"), do: "."
+  defp thousand_separator("it"), do: "."
   defp thousand_separator("uk"), do: " "
   defp thousand_separator("fr"), do: " "
   defp thousand_separator(_other_locale), do: ","
 
   defp decimal_separator("de"), do: ","
+  defp decimal_separator("it"), do: ","
   defp decimal_separator("uk"), do: ","
   defp decimal_separator("fr"), do: ","
   defp decimal_separator(_other_locale), do: "."

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -1,0 +1,1070 @@
+## Template for translations
+msgid ""
+msgstr ""
+"Language: it\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: Navigation
+msgid "overview"
+msgstr "panoramica"
+
+msgid "schedule"
+msgstr "pianifica"
+
+msgid "booking"
+msgstr "prenotazione"
+
+msgid "confirmation"
+msgstr "conferma"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/overview_component.ex:182
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/overview_component.ex:123
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/schedule_component.ex:313
+#, elixir-autogen
+msgid "next"
+msgstr "successivo"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/booking_component.ex:155
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule_component.ex:353
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/booking_component.ex:151
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/schedule_component.ex:302
+#, elixir-autogen
+msgid "back"
+msgstr "indietro"
+
+msgid "continue"
+msgstr "continua"
+
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/booking_component.ex:184
+#, elixir-autogen
+msgid "submit"
+msgstr "invia"
+
+msgid "schedule_another"
+msgstr "pianifica un altro"
+
+msgid "close"
+msgstr "chiudi"
+
+#: Overview Step
+msgid "select_meeting_duration"
+msgstr "seleziona la durata dell'incontro"
+
+msgid "choose_meeting_type"
+msgstr "scegli il tipo di incontro"
+
+msgid "select_duration"
+msgstr "seleziona durata"
+
+#: Schedule Step
+msgid "select_date"
+msgstr "seleziona data"
+
+msgid "select_time"
+msgstr "seleziona ora"
+
+msgid "no_available_slots"
+msgstr "nessuno slot disponibile"
+
+msgid "timezone"
+msgstr "fuso orario"
+
+msgid "search_timezone"
+msgstr "cerca fuso orario"
+
+msgid "choose_date_time"
+msgstr "scegli data e ora"
+
+msgid "select_date_time"
+msgstr "seleziona data e ora"
+
+msgid "available"
+msgstr "disponibile"
+
+msgid "unavailable"
+msgstr "non disponibile"
+
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/booking_component.ex:106
+#, elixir-autogen
+msgid "name"
+msgstr "nome"
+
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/booking_component.ex:117
+#, elixir-autogen
+msgid "email"
+msgstr "email"
+
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/booking_component.ex:130
+#, elixir-autogen
+msgid "message_optional"
+msgstr "messaggio (opzionale)"
+
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/booking_component.ex:107
+#, elixir-autogen
+msgid "enter_full_name"
+msgstr "inserisci il nome completo"
+
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/booking_component.ex:119
+#, elixir-autogen
+msgid "enter_email"
+msgstr "inserisci l'email"
+
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/booking_component.ex:131
+#, elixir-autogen
+msgid "add_details"
+msgstr "aggiungi dettagli"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/booking_component.ex:168
+#, elixir-autogen
+msgid "book_meeting"
+msgstr "prenota incontro"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/booking_component.ex:168
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/booking_component.ex:184
+#, elixir-autogen
+msgid "reschedule_meeting"
+msgstr "riprogramma incontro"
+
+msgid "enter_details"
+msgstr "inserisci dettagli"
+
+msgid "your_information"
+msgstr "le tue informazioni"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/confirmation_component.ex:76
+#, elixir-autogen
+msgid "meeting_confirmed"
+msgstr "incontro confermato"
+
+msgid "confirmation_email_sent"
+msgstr "email di conferma inviata"
+
+msgid "add_to_calendar"
+msgstr "aggiungi al calendario"
+
+msgid "meeting_details"
+msgstr "dettagli dell'incontro"
+
+msgid "date_and_time"
+msgstr "data e ora"
+
+msgid "duration"
+msgstr "durata"
+
+msgid "location"
+msgstr "luogo"
+
+msgid "thank_you"
+msgstr "grazie"
+
+msgid "see_you_soon"
+msgstr "a presto"
+
+#: Time formats
+msgid "minutes"
+msgstr "minuti"
+
+msgid "hour"
+msgstr "ora"
+
+msgid "hours"
+msgstr "ore"
+
+msgid "minute"
+msgstr "minuto"
+
+#: Calendar
+msgid "january"
+msgstr "gennaio"
+
+msgid "february"
+msgstr "febbraio"
+
+msgid "march"
+msgstr "marzo"
+
+msgid "april"
+msgstr "aprile"
+
+msgid "may"
+msgstr "maggio"
+
+msgid "june"
+msgstr "giugno"
+
+msgid "july"
+msgstr "luglio"
+
+msgid "august"
+msgstr "agosto"
+
+msgid "september"
+msgstr "settembre"
+
+msgid "october"
+msgstr "ottobre"
+
+msgid "november"
+msgstr "novembre"
+
+msgid "december"
+msgstr "dicembre"
+
+msgid "sunday"
+msgstr "domenica"
+
+msgid "monday"
+msgstr "lunedì"
+
+msgid "tuesday"
+msgstr "martedì"
+
+msgid "wednesday"
+msgstr "mercoledì"
+
+msgid "thursday"
+msgstr "giovedì"
+
+msgid "friday"
+msgstr "venerdì"
+
+msgid "saturday"
+msgstr "sabato"
+
+msgid "sun"
+msgstr "dom"
+
+msgid "mon"
+msgstr "lun"
+
+msgid "tue"
+msgstr "mar"
+
+msgid "wed"
+msgstr "mer"
+
+msgid "thu"
+msgstr "gio"
+
+msgid "fri"
+msgstr "ven"
+
+msgid "sat"
+msgstr "sab"
+
+#: Language UI
+msgid "change_language"
+msgstr "cambia lingua"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/booking_component.ex:133
+#, elixir-autogen, elixir-format
+msgid "Additional Message (Optional)"
+msgstr "Messaggio aggiuntivo (Opzionale)"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/booking_component.ex:191
+#, elixir-autogen, elixir-format
+msgid "Click to schedule your meeting"
+msgstr "Clicca per programmare il tuo incontro"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/booking_component.ex:118
+#, elixir-autogen, elixir-format
+msgid "Email Address"
+msgstr "Indirizzo email"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/booking_component.ex:71
+#, elixir-autogen, elixir-format
+msgid "Enter Your Details"
+msgstr "Inserisci i tuoi dettagli"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/overview_component.ex:121
+#, elixir-autogen, elixir-format
+msgid "Hi, I'm %{name}. Select how much time you need for our conversation."
+msgstr "Ciao, sono %{name}. Seleziona quanto tempo ti serve per la nostra conversazione."
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/booking_component.ex:107
+#, elixir-autogen, elixir-format
+msgid "John Doe"
+msgstr "Mario Rossi"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/booking_component.ex:134
+#, elixir-autogen, elixir-format
+msgid "Let me know what you'd like to discuss..."
+msgstr "Fammi sapere di cosa vorresti discutere..."
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/overview_component.ex:115
+#, elixir-autogen, elixir-format
+msgid "Let's Connect!"
+msgstr "Mettiamoci in contatto!"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/confirmation_component.ex:74
+#, elixir-autogen, elixir-format
+msgid "Meeting Rescheduled!"
+msgstr "Incontro riprogrammato!"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/overview_component.ex:131
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/overview_component.ex:79
+#, elixir-autogen, elixir-format
+msgid "No meeting types available"
+msgstr "Nessun tipo di incontro disponibile"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/overview_component.ex:132
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/overview_component.ex:80
+#, elixir-autogen, elixir-format
+msgid "Please contact the organizer"
+msgstr "Si prega di contattare l'organizzatore"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/booking_component.ex:190
+#, elixir-autogen, elixir-format
+msgid "Please fill in all required fields"
+msgstr "Si prega di compilare tutti i campi obbligatori"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/overview_component.ex:178
+#, elixir-autogen, elixir-format
+msgid "Please select a meeting duration first"
+msgstr "Si prega di selezionare prima la durata dell'incontro"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/overview_component.ex:123
+#, elixir-autogen, elixir-format
+msgid "Select how much time you need for our conversation."
+msgstr "Seleziona quanto tempo ti serve per la nostra conversazione."
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/booking_component.ex:189
+#, elixir-autogen, elixir-format
+msgid "Verifying slot availability and creating your meeting..."
+msgstr "Verifica della disponibilità e creazione dell'incontro..."
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/booking_component.ex:162
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/booking_component.ex:182
+#, elixir-autogen, elixir-format
+msgid "Verifying..."
+msgstr "Verifica in corso..."
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/booking_component.ex:80
+#, elixir-autogen, elixir-format
+msgid "You're booking a %{duration} meeting"
+msgstr "Stai prenotando un incontro di %{duration}"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/booking_component.ex:76
+#, elixir-autogen, elixir-format
+msgid "You're booking a %{duration} meeting with %{name}"
+msgstr "Stai prenotando un incontro di %{duration} con %{name}"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/booking_component.ex:106
+#, elixir-autogen, elixir-format
+msgid "Your Name"
+msgstr "Il tuo nome"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/booking_component.ex:120
+#, elixir-autogen, elixir-format
+msgid "john@example.com"
+msgstr "mario@esempio.it"
+
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/overview_component.ex:69
+#, elixir-autogen, elixir-format
+msgid "Hi! I'm %{name}."
+msgstr "Ciao! Sono %{name}."
+
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/overview_component.ex:72
+#, elixir-autogen, elixir-format
+msgid "Pick a meeting duration below."
+msgstr "Scegli una durata per l'incontro qui sotto."
+
+#: lib/tymeslot_web/themes/rhythm/shared/organizer_header.ex:34
+#, elixir-autogen, elixir-format
+msgid "Schedule with"
+msgstr "Pianifica con"
+
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/overview_component.ex:55
+#, elixir-autogen, elixir-format
+msgid "Schedule with %{name}"
+msgstr "Pianifica con %{name}"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:247
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:255
+#, elixir-autogen, elixir-format
+msgid "%{count} hours"
+msgstr "%{count} ore"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:258
+#, elixir-autogen, elixir-format
+msgid "%{count} minutes"
+msgstr "%{count} minuti"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:50
+#, elixir-autogen, elixir-format
+msgid "%{date} at %{time}"
+msgstr "%{date} alle %{time}"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule/panels.ex:280
+#, elixir-autogen, elixir-format
+msgid "%{days} days in advance"
+msgstr "%{days} giorni in anticipo"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:260
+#, elixir-autogen, elixir-format
+msgid "%{hour_text} %{minute_text}"
+msgstr "%{hour_text} %{minute_text}"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:241
+#, elixir-autogen, elixir-format
+msgid "%{minutes} minutes"
+msgstr "%{minutes} minuti"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule/panels.ex:301
+#, elixir-autogen, elixir-format
+msgid "%{months} months in advance"
+msgstr "%{months} mesi in anticipo"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:89
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day}, %{year}"
+msgstr "%{day} %{month} %{year}"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:198
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:214
+#, elixir-autogen, elixir-format
+msgid "%{month} %{year}"
+msgstr "%{month} %{year}"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/confirmation_component.ex:81
+#, elixir-autogen, elixir-format
+msgid "%{name}, your meeting %{organizer} has been rescheduled."
+msgstr "%{name}, il tuo incontro %{organizer} è stato riprogrammato."
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/confirmation_component.ex:83
+#, elixir-autogen, elixir-format
+msgid "%{name}, your meeting %{organizer} is all set."
+msgstr "%{name}, il tuo incontro %{organizer} è confermato."
+
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/confirmation_component.ex:59
+#, elixir-autogen, elixir-format
+msgid "%{name}, your meeting %{organizer} is confirmed"
+msgstr "%{name}, il tuo incontro %{organizer} è confermato"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:220
+#, elixir-autogen, elixir-format
+msgid "%{start_month} - %{end_month} %{year}"
+msgstr "%{start_month} - %{end_month} %{year}"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:65
+#, elixir-autogen, elixir-format
+msgid "%{time} %{timezone}"
+msgstr "%{time} %{timezone}"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:69
+#, elixir-autogen, elixir-format
+msgid "%{time} UTC"
+msgstr "%{time} UTC"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule/panels.ex:64
+#, elixir-autogen, elixir-format
+msgid "%{time} local time"
+msgstr "%{time} ora locale"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:40
+#, elixir-autogen, elixir-format
+msgid "%{weekday}, %{day} %{month} %{year} at %{time} %{timezone}"
+msgstr "%{weekday}, %{day} %{month} %{year} alle %{time} %{timezone}"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule/panels.ex:298
+#, elixir-autogen, elixir-format
+msgid "%{weeks} weeks in advance"
+msgstr "%{weeks} settimane in anticipo"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule/panels.ex:303
+#, elixir-autogen, elixir-format
+msgid "%{years} years in advance"
+msgstr "%{years} anni in anticipo"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule/panels.ex:277
+#, elixir-autogen, elixir-format
+msgid "1 day in advance"
+msgstr "1 giorno in anticipo"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:243
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:255
+#, elixir-autogen, elixir-format
+msgid "1 hour"
+msgstr "1 ora"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:238
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:258
+#, elixir-autogen, elixir-format
+msgid "1 minute"
+msgstr "1 minuto"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule/panels.ex:287
+#, elixir-autogen, elixir-format
+msgid "1 month in advance"
+msgstr "1 mese in anticipo"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule/panels.ex:282
+#, elixir-autogen, elixir-format
+msgid "1 week in advance"
+msgstr "1 settimana in anticipo"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule/panels.ex:292
+#, elixir-autogen, elixir-format
+msgid "1 year in advance"
+msgstr "1 anno in anticipo"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule/panels.ex:294
+#, elixir-autogen, elixir-format
+msgid "90 days in advance"
+msgstr "90 giorni in anticipo"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:20
+#, elixir-autogen, elixir-format
+msgid "Afternoon"
+msgstr "Pomeriggio"
+
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/confirmation_component.ex:101
+#, elixir-autogen, elixir-format
+msgid "Appointment host"
+msgstr "Organizzatore dell'appuntamento"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:137
+#, elixir-autogen, elixir-format
+msgid "April"
+msgstr "Aprile"
+
+#: lib/tymeslot_web/themes/quill/meeting/cancel.ex:131
+#: lib/tymeslot_web/themes/rhythm/meeting/cancel.ex:91
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to cancel this appointment?"
+msgstr "Sei sicuro di voler annullare questo appuntamento?"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:141
+#, elixir-autogen, elixir-format
+msgid "August"
+msgstr "Agosto"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule/panels.ex:159
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/schedule_component.ex:238
+#, elixir-autogen, elixir-format
+msgid "Available Times"
+msgstr "Orari disponibili"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule_component.ex:179
+#, elixir-autogen, elixir-format
+msgid "Bookings available up to %{advance}"
+msgstr "Prenotazioni disponibili fino a %{advance}"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule_component.ex:268
+#, elixir-autogen, elixir-format
+msgid "Calendar is loading slowly"
+msgstr "Il calendario si sta caricando lentamente"
+
+#: lib/tymeslot_web/themes/quill/meeting/cancel.ex:128
+#: lib/tymeslot_web/themes/rhythm/meeting/cancel.ex:87
+#, elixir-autogen, elixir-format
+msgid "Cancel Appointment"
+msgstr "Annulla appuntamento"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/confirmation_component.ex:111
+#, elixir-autogen, elixir-format
+msgid "Confirmation sent to"
+msgstr "Conferma inviata a"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/confirmation_component.ex:176
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/confirmation_component.ex:78
+#: lib/tymeslot_web/themes/rhythm/shared/meeting_ticket.ex:50
+#: lib/tymeslot_web/themes/shared/components/meeting_details.ex:30
+#, elixir-autogen, elixir-format
+msgid "Date"
+msgstr "Data"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:145
+#, elixir-autogen, elixir-format
+msgid "December"
+msgstr "Dicembre"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule_component.ex:187
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule_component.ex:189
+#, elixir-autogen, elixir-format
+msgid "Duration: %{duration}"
+msgstr "Durata: %{duration}"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:21
+#, elixir-autogen, elixir-format
+msgid "Evening"
+msgstr "Sera"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:175
+#, elixir-autogen, elixir-format
+msgid "FRI"
+msgstr "VEN"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:135
+#, elixir-autogen, elixir-format
+msgid "February"
+msgstr "Febbraio"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule_component.ex:310
+#, elixir-autogen, elixir-format
+msgid "Fri"
+msgstr "Ven"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:159
+#, elixir-autogen, elixir-format
+msgid "Friday"
+msgstr "Venerdì"
+
+#: lib/tymeslot_web/themes/quill/meeting/cancel.ex:66
+#: lib/tymeslot_web/themes/rhythm/meeting/cancel.ex:65
+#, elixir-autogen, elixir-format
+msgid "Great! Your meeting is still scheduled as planned."
+msgstr "Ottimo! Il tuo incontro è ancora programmato come previsto."
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:55
+#, elixir-autogen, elixir-format
+msgid "Invalid date/time"
+msgstr "Data/ora non valida"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:134
+#, elixir-autogen, elixir-format
+msgid "January"
+msgstr "Gennaio"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:140
+#, elixir-autogen, elixir-format
+msgid "July"
+msgstr "Luglio"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:139
+#, elixir-autogen, elixir-format
+msgid "June"
+msgstr "Giugno"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule/panels.ex:166
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/schedule_component.ex:244
+#, elixir-autogen, elixir-format
+msgid "Loading available times..."
+msgstr "Caricamento orari disponibili..."
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:171
+#, elixir-autogen, elixir-format
+msgid "MON"
+msgstr "LUN"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:136
+#, elixir-autogen, elixir-format
+msgid "March"
+msgstr "Marzo"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:138
+#, elixir-autogen, elixir-format
+msgid "May"
+msgstr "Maggio"
+
+#: lib/tymeslot_web/themes/quill/meeting/cancel_confirmed.ex:57
+#: lib/tymeslot_web/themes/rhythm/meeting/cancel_confirmed.ex:49
+#, elixir-autogen, elixir-format
+msgid "Meeting Cancelled"
+msgstr "Incontro annullato"
+
+#: lib/tymeslot_web/themes/quill/meeting/cancel.ex:63
+#: lib/tymeslot_web/themes/rhythm/meeting/cancel.ex:61
+#, elixir-autogen, elixir-format
+msgid "Meeting Confirmed"
+msgstr "Incontro confermato"
+
+#: lib/tymeslot_web/themes/quill/meeting/cancel.ex:77
+#: lib/tymeslot_web/themes/quill/meeting/cancel.ex:142
+#: lib/tymeslot_web/themes/rhythm/meeting/cancel.ex:98
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/confirmation_component.ex:65
+#, elixir-autogen, elixir-format
+msgid "Meeting Details"
+msgstr "Dettagli dell'incontro"
+
+#: lib/tymeslot_web/themes/rhythm/shared/meeting_ticket.ex:71
+#: lib/tymeslot_web/themes/shared/components/meeting_details.ex:50
+#, elixir-autogen, elixir-format
+msgid "Meeting with"
+msgstr "Incontro con"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule_component.ex:310
+#, elixir-autogen, elixir-format
+msgid "Mon"
+msgstr "Lun"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:155
+#, elixir-autogen, elixir-format
+msgid "Monday"
+msgstr "Lunedì"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:19
+#, elixir-autogen, elixir-format
+msgid "Morning"
+msgstr "Mattina"
+
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/confirmation_component.ex:133
+#, elixir-autogen, elixir-format
+msgid "Need to make changes? Check your email for reschedule options"
+msgstr "Devi apportare modifiche? Controlla la tua email per le opzioni di riprogrammazione"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/confirmation_component.ex:132
+#, elixir-autogen, elixir-format
+msgid "Need to reschedule? Check your confirmation email."
+msgstr "Devi riprogrammare? Controlla la tua email di conferma."
+
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/booking_component.ex:69
+#, elixir-autogen, elixir-format
+msgid "No time selected"
+msgstr "Nessun orario selezionato"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:144
+#, elixir-autogen, elixir-format
+msgid "November"
+msgstr "Novembre"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:143
+#, elixir-autogen, elixir-format
+msgid "October"
+msgstr "Ottobre"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule/panels.ex:220
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/schedule_component.ex:288
+#, elixir-autogen, elixir-format
+msgid "Please select a date to see available times"
+msgstr "Si prega di selezionare una data per vedere gli orari disponibili"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule/panels.ex:202
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/schedule_component.ex:281
+#, elixir-autogen, elixir-format
+msgid "Please select another date"
+msgstr "Si prega di selezionare un'altra data"
+
+#: lib/tymeslot_web/themes/quill/meeting/reschedule.ex:62
+#: lib/tymeslot_web/themes/rhythm/meeting/reschedule.ex:55
+#, elixir-autogen, elixir-format
+msgid "Reschedule Appointment"
+msgstr "Riprogramma appuntamento"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:176
+#, elixir-autogen, elixir-format
+msgid "SAT"
+msgstr "SAB"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:177
+#, elixir-autogen, elixir-format
+msgid "SUN"
+msgstr "DOM"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule_component.ex:310
+#, elixir-autogen, elixir-format
+msgid "Sat"
+msgstr "Sab"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:160
+#, elixir-autogen, elixir-format
+msgid "Saturday"
+msgstr "Sabato"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/confirmation_component.ex:127
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/confirmation_component.ex:129
+#, elixir-autogen, elixir-format
+msgid "Schedule Another Meeting"
+msgstr "Pianifica un altro incontro"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule/panels.ex:108
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/schedule_component.ex:141
+#, elixir-autogen, elixir-format
+msgid "Search cities, countries, or timezones..."
+msgstr "Cerca città, paesi o fusi orari..."
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule_component.ex:259
+#, elixir-autogen, elixir-format
+msgid "Select a Date"
+msgstr "Seleziona una data"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule_component.ex:174
+#, elixir-autogen, elixir-format
+msgid "Select a Date & Time"
+msgstr "Seleziona data e ora"
+
+#: lib/tymeslot_web/themes/quill/meeting/reschedule.ex:65
+#: lib/tymeslot_web/themes/rhythm/meeting/reschedule.ex:59
+#, elixir-autogen, elixir-format
+msgid "Select a new time for your meeting"
+msgstr "Seleziona un nuovo orario per il tuo incontro"
+
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/confirmation_component.ex:117
+#, elixir-autogen, elixir-format
+msgid "Sent to"
+msgstr "Inviata a"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:142
+#, elixir-autogen, elixir-format
+msgid "September"
+msgstr "Settembre"
+
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/schedule_component.ex:200
+#, elixir-autogen, elixir-format
+msgid "Service slow"
+msgstr "Servizio lento"
+
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/confirmation_component.ex:51
+#, elixir-autogen, elixir-format
+msgid "Successfully Rescheduled!"
+msgstr "Riprogrammato con successo!"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule_component.ex:310
+#, elixir-autogen, elixir-format
+msgid "Sun"
+msgstr "Dom"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:161
+#, elixir-autogen, elixir-format
+msgid "Sunday"
+msgstr "Domenica"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:174
+#, elixir-autogen, elixir-format
+msgid "THU"
+msgstr "GIO"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:172
+#, elixir-autogen, elixir-format
+msgid "TUE"
+msgstr "MAR"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule/panels.ex:201
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/schedule_component.ex:280
+#, elixir-autogen, elixir-format
+msgid "This date is fully booked"
+msgstr "Questa data è al completo"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule_component.ex:310
+#, elixir-autogen, elixir-format
+msgid "Thu"
+msgstr "Gio"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:158
+#, elixir-autogen, elixir-format
+msgid "Thursday"
+msgstr "Giovedì"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule_component.ex:310
+#, elixir-autogen, elixir-format
+msgid "Tue"
+msgstr "Mar"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:156
+#, elixir-autogen, elixir-format
+msgid "Tuesday"
+msgstr "Martedì"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:116
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:126
+#, elixir-autogen, elixir-format
+msgid "Unknown duration"
+msgstr "Durata sconosciuta"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:173
+#, elixir-autogen, elixir-format
+msgid "WED"
+msgstr "MER"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule_component.ex:310
+#, elixir-autogen, elixir-format
+msgid "Wed"
+msgstr "Mer"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:157
+#, elixir-autogen, elixir-format
+msgid "Wednesday"
+msgstr "Mercoledì"
+
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/confirmation_component.ex:53
+#, elixir-autogen, elixir-format
+msgid "You're All Set!"
+msgstr "È tutto pronto!"
+
+#: lib/tymeslot_web/themes/quill/meeting/cancel_confirmed.ex:60
+#: lib/tymeslot_web/themes/rhythm/meeting/cancel_confirmed.ex:53
+#, elixir-autogen, elixir-format
+msgid "Your meeting has been successfully cancelled."
+msgstr "Il tuo incontro è stato annullato con successo."
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule/panels.ex:41
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/schedule_component.ex:109
+#, elixir-autogen, elixir-format
+msgid "Your timezone"
+msgstr "Il tuo fuso orario"
+
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/booking_component.ex:80
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/booking_component.ex:82
+#, elixir-autogen, elixir-format
+msgid "meeting"
+msgstr "incontro"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule_component.ex:363
+#, elixir-autogen, elixir-format
+msgid "next_step"
+msgstr "fase_successiva"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/schedule/panels.ex:275
+#, elixir-autogen, elixir-format
+msgid "same day only"
+msgstr "solo lo stesso giorno"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:186
+#, elixir-autogen, elixir-format
+msgid "time_format_type"
+msgstr "tipo_formato_ora"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/confirmation_component.ex:215
+#: lib/tymeslot_web/themes/rhythm/scheduling/components/confirmation_component.ex:150
+#, elixir-autogen, elixir-format
+msgid "with %{name}"
+msgstr "con %{name}"
+
+#: lib/tymeslot_web/themes/quill/meeting/cancel.ex:178
+#: lib/tymeslot_web/themes/rhythm/meeting/cancel.ex:140
+#, elixir-autogen, elixir-format
+msgid "A cancellation email will be sent to all participants"
+msgstr "Verrà inviata un'email di annullamento a tutti i partecipanti"
+
+#: lib/tymeslot_web/themes/quill/meeting/cancel.ex:187
+#: lib/tymeslot_web/themes/rhythm/meeting/cancel.ex:166
+#, elixir-autogen, elixir-format
+msgid "Cancelling..."
+msgstr "Annullamento..."
+
+#: lib/tymeslot_web/themes/quill/meeting/reschedule.ex:105
+#, elixir-autogen, elixir-format
+msgid "Choose New Time"
+msgstr "Scegli un nuovo orario"
+
+#: lib/tymeslot_web/themes/quill/meeting/reschedule.ex:76
+#, elixir-autogen, elixir-format
+msgid "Current Meeting"
+msgstr "Incontro attuale"
+
+#: lib/tymeslot_web/themes/rhythm/meeting/reschedule.ex:65
+#, elixir-autogen, elixir-format
+msgid "Current Meeting Details"
+msgstr "Dettagli dell'incontro attuale"
+
+#: lib/tymeslot_web/themes/quill/meeting/cancel.ex:102
+#: lib/tymeslot_web/themes/rhythm/meeting/cancel.ex:153
+#, elixir-autogen, elixir-format
+msgid "Done"
+msgstr "Fatto"
+
+#: lib/tymeslot_web/themes/rhythm/meeting/reschedule.ex:92
+#, elixir-autogen, elixir-format
+msgid "Go to Calendar"
+msgstr "Vai al calendario"
+
+#: lib/tymeslot_web/themes/quill/meeting/cancel.ex:203
+#: lib/tymeslot_web/themes/rhythm/meeting/cancel.ex:179
+#, elixir-autogen, elixir-format
+msgid "Keep Meeting"
+msgstr "Mantieni incontro"
+
+#: lib/tymeslot_web/themes/quill/meeting/reschedule.ex:97
+#: lib/tymeslot_web/themes/rhythm/meeting/reschedule.ex:80
+#, elixir-autogen, elixir-format
+msgid "Ready to pick a new time? Let's find one that works better for you."
+msgstr "Pronto a scegliere un nuovo orario? Troviamone uno che funzioni meglio per te."
+
+#: lib/tymeslot_web/themes/quill/meeting/cancel_confirmed.ex:93
+#: lib/tymeslot_web/themes/rhythm/meeting/cancel_confirmed.ex:81
+#, elixir-autogen, elixir-format
+msgid "Schedule a New Meeting"
+msgstr "Pianifica un nuovo incontro"
+
+#: lib/tymeslot_web/themes/quill/meeting/cancel.ex:98
+#: lib/tymeslot_web/themes/rhythm/meeting/cancel.ex:126
+#, elixir-autogen, elixir-format
+msgid "We look forward to seeing you at the scheduled time."
+msgstr "Non vediamo l'ora di vederti all'orario programmato."
+
+#: lib/tymeslot_web/themes/quill/meeting/cancel.ex:192
+#: lib/tymeslot_web/themes/rhythm/meeting/cancel.ex:168
+#, elixir-autogen, elixir-format
+msgid "Yes, Cancel Meeting"
+msgstr "Sì, annulla l'incontro"
+
+#: lib/tymeslot_web/themes/quill/meeting/cancel_confirmed.ex:82
+#: lib/tymeslot_web/themes/rhythm/meeting/cancel_confirmed.ex:69
+#, elixir-autogen, elixir-format
+msgid "Cancellation emails have been sent to all participants."
+msgstr "Le email di annullamento sono state inviate a tutti i partecipanti."
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:227
+#, elixir-autogen, elixir-format
+msgid "%{start_month} %{start_year} - %{end_month} %{end_year}"
+msgstr "%{start_month} %{start_year} - %{end_month} %{end_year}"
+
+#: lib/tymeslot_web/components/step_navigation.ex:21
+#: lib/tymeslot_web/themes/quill/scheduling/components/confirmation_component.ex:178
+#, elixir-autogen, elixir-format
+msgid "Duration"
+msgstr "Durata"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/confirmation_component.ex:177
+#, elixir-autogen, elixir-format
+msgid "Time"
+msgstr "Ora"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/confirmation_component.ex:179
+#, elixir-autogen, elixir-format
+msgid "Timezone"
+msgstr "Fuso orario"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/overview_component.ex:150
+#, elixir-autogen, elixir-format
+msgid "15 Minutes"
+msgstr "15 Minuti"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/overview_component.ex:160
+#, elixir-autogen, elixir-format
+msgid "30 Minutes"
+msgstr "30 Minuti"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/overview_component.ex:162
+#, elixir-autogen, elixir-format
+msgid "In-depth discussion or detailed review"
+msgstr "Discussione approfondita o revisione dettagliata"
+
+#: lib/tymeslot_web/themes/quill/scheduling/components/overview_component.ex:152
+#, elixir-autogen, elixir-format
+msgid "Quick chat or brief consultation"
+msgstr "Chiacchierata veloce o breve consultazione"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:18
+#, elixir-autogen, elixir-format
+msgid "Early Morning"
+msgstr "Mattina presto"
+
+#: lib/tymeslot_web/themes/shared/localization_helpers.ex:22
+#, elixir-autogen, elixir-format
+msgid "Late Night"
+msgstr "Tarda notte"
+
+#: lib/tymeslot_web/components/step_navigation.ex:48
+#, elixir-autogen, elixir-format
+msgid "Confirmation"
+msgstr "Conferma"
+
+#: lib/tymeslot_web/components/step_navigation.ex:30
+#, elixir-autogen, elixir-format
+msgid "Date & Time"
+msgstr "Data e Ora"
+
+#: lib/tymeslot_web/components/step_navigation.ex:39
+#, elixir-autogen, elixir-format
+msgid "Details"
+msgstr "Dettagli"
+
+#: lib/tymeslot_web/live/dashboard/calendar_grid/modals/confirm_discard_attendees_modal.ex:24
+#, elixir-autogen, elixir-format
+msgid "1 attendee hasn't been invited yet. Discard?"
+msgid_plural "%{count} attendees haven't been invited yet. Discard?"
+msgstr[0] "1 partecipante non è ancora stato invitato. Scartare?"
+msgstr[1] "%{count} partecipanti non sono ancora stati invitati. Scartare?"

--- a/priv/gettext/it/LC_MESSAGES/emails.po
+++ b/priv/gettext/it/LC_MESSAGES/emails.po
@@ -1,0 +1,1473 @@
+## This file is a PO Template file.
+msgid ""
+msgstr ""
+"Language: it\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: lib/tymeslot/emails/shared/text_body_helper.ex:90
+#, elixir-autogen, elixir-format
+msgid "ACTIONS:"
+msgstr "AZIONI:"
+
+#: lib/tymeslot/emails/shared/text_body_helper.ex:126
+#, elixir-autogen, elixir-format
+msgid "ATTENDEE INFORMATION:"
+msgstr "INFORMAZIONI PARTECIPANTE:"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:94
+#, elixir-autogen, elixir-format
+msgid "Appointment Confirmed - %{date} with %{name}"
+msgstr "Appuntamento confermato - %{date} con %{name}"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:169
+#, elixir-autogen, elixir-format
+msgid "Appointment Confirmed!"
+msgstr "Appuntamento confermato!"
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:166
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:209
+#, elixir-autogen, elixir-format
+msgid "Best,"
+msgstr "Cordiali saluti,"
+
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:133
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:166
+#: lib/tymeslot/emails/templates/reschedule_request.ex:109
+#, elixir-autogen, elixir-format
+msgid "CANCELLED APPOINTMENT DETAILS:"
+msgstr "DETTAGLI APPUNTAMENTO ANNULLATO:"
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:56
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:112
+#, elixir-autogen, elixir-format
+msgid "Cancel"
+msgstr "Annulla"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:67
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:120
+#, elixir-autogen, elixir-format
+msgid "Cancel Appointment"
+msgstr "Annulla appuntamento"
+
+#: lib/tymeslot/emails/shared/text_body_helper.ex:80
+#, elixir-autogen, elixir-format
+msgid "Cancel:"
+msgstr "Annulla:"
+
+#: lib/tymeslot/emails/templates/reschedule_request.ex:51
+#, elixir-autogen, elixir-format
+msgid "Cancelled Appointment Details"
+msgstr "Dettagli appuntamento annullato"
+
+#: lib/tymeslot/emails/templates/reschedule_request.ex:58
+#, elixir-autogen, elixir-format
+msgid "Choose a New Time"
+msgstr "Scegli un nuovo orario"
+
+#: lib/tymeslot/emails/templates/reschedule_request.ex:118
+#, elixir-autogen, elixir-format
+msgid "Choose a New Time:"
+msgstr "Scegli un nuovo orario:"
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:160
+#, elixir-autogen, elixir-format
+msgid "DETAILS:"
+msgstr "DETTAGLI:"
+
+#: lib/tymeslot/emails/shared/text_body_helper.ex:23
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:103
+#: lib/tymeslot/emails/templates/external_booking_change.ex:168
+#: lib/tymeslot/emails/templates/external_booking_change.ex:192
+#: lib/tymeslot/emails/templates/reschedule_request.ex:110
+#, elixir-autogen, elixir-format
+msgid "Date:"
+msgstr "Data:"
+
+#: lib/tymeslot/emails/shared/meeting_components.ex:350
+#, elixir-autogen, elixir-format
+msgid "Duration"
+msgstr "Durata"
+
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:105
+#: lib/tymeslot/emails/templates/external_booking_change.ex:170
+#: lib/tymeslot/emails/templates/external_booking_change.ex:194
+#: lib/tymeslot/emails/templates/reschedule_request.ex:111
+#, elixir-autogen, elixir-format
+msgid "Duration:"
+msgstr "Durata:"
+
+#: lib/tymeslot/emails/shared/text_body_helper.ex:114
+#, elixir-autogen, elixir-format
+msgid "Email:"
+msgstr "Email:"
+
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:129
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:171
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:156
+#: lib/tymeslot/emails/templates/email_change_verification.ex:18
+#: lib/tymeslot/emails/templates/email_change_verification.ex:98
+#: lib/tymeslot/emails/templates/email_verification.ex:17
+#: lib/tymeslot/emails/templates/email_verification.ex:48
+#: lib/tymeslot/emails/templates/password_reset.ex:17
+#: lib/tymeslot/emails/templates/password_reset.ex:49
+#: lib/tymeslot/emails/templates/reschedule_request.ex:105
+#, elixir-autogen, elixir-format
+msgid "Hi %{name},"
+msgstr "Ciao %{name},"
+
+#: lib/tymeslot/emails/templates/reschedule_request.ex:71
+#, elixir-autogen, elixir-format
+msgid "Hi %{name}, I need to reschedule our upcoming meeting. Could you please select a new time that works for you?"
+msgstr "Ciao %{name}, ho bisogno di riprogrammare il nostro prossimo incontro. Potresti selezionare un nuovo orario che funzioni per te?"
+
+#: lib/tymeslot/emails/templates/reschedule_request.Official116
+#, elixir-autogen, elixir-format
+msgid "I apologize for any inconvenience this may cause. Your current appointment has been cancelled, and I'd like to help you reschedule at your earliest convenience."
+msgstr "Mi scuso per l'inconveniente. Il tuo appuntamento attuale è stato annullato e vorrei aiutarti a riprogrammarlo al più presto."
+
+#: lib/tymeslot/emails/templates/reschedule_request.ex:107
+#, elixir-autogen, elixir-format
+msgid "I need to reschedule our upcoming meeting. Could you please select a new time that works for you?"
+msgstr "Ho bisogno di riprogrammare il nostro prossimo incontro. Potresti selezionare un nuovo orario che funzioni per te?"
+
+#: lib/tymeslot/emails/appointment_builder.ex:191
+#: lib/tymeslot/emails/appointment_builder.ex:209
+#, elixir-autogen, elixir-format
+msgid "I'll send you a reminder %{label} before our appointment."
+msgstr "Ti invierò un promemoria %{label} prima del nostro appuntamento."
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:158
+#, elixir-autogen, elixir-format
+msgid "I'm looking forward to our conversation!"
+msgstr "Non vedo l'ora della nostra conversazione!"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:173
+#, elixir-autogen, elixir-format
+msgid "I'm looking forward to our meeting. I've blocked the time on my calendar and will be ready for you."
+msgstr "Non vedo l'ora del nostro incontro. Ho bloccato l'orario sul mio calendario e sarò pronto per te."
+
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:55
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:142
+#, elixir-autogen, elixir-format
+msgid "If you have any questions, please don't hesitate to reach out."
+msgstr "Se hai domande, non esitare a contattarci."
+
+#: lib/tymeslot/emails/shared/text_body_helper.ex:45
+#, elixir-autogen, elixir-format
+msgid "JOIN VIDEO MEETING:"
+msgstr "PARTECIPA ALLA VIDEOCHIAMATA:"
+
+#: lib/tymeslot/emails/shared/meeting_components.ex:101
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:51
+#, elixir-autogen, elixir-format
+msgid "Join Meeting"
+msgstr "Partecipa all'incontro"
+
+#: lib/tymeslot/emails/shared/meeting_components.ex:100
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:62
+#, elixir-autogen, elixir-format
+msgid "Join Video Meeting"
+msgstr "Partecipa alla videochiamata"
+
+#: lib/tymeslot/emails/shared/meeting_components.ex:354
+#: lib/tymeslot/emails/templates/event_update_notification.ex:182
+#, elixir-autogen, elixir-format
+msgid "Location"
+msgstr "Luogo"
+
+#: lib/tymeslot/emails/shared/text_body_helper.ex:149
+#: lib/tymeslot/emails/shared/text_body_helper.ex:172
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:106
+#: lib/tymeslot/emails/templates/external_booking_change.ex:171
+#: lib/tymeslot/emails/templates/external_booking_change.ex:195
+#: lib/tymeslot/emails/templates/reschedule_request.ex:112
+#, elixir-autogen, elixir-format
+msgid "Location:"
+msgstr "Luogo:"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:181
+#, elixir-autogen, elixir-format
+msgid "Looking forward to meeting you!"
+msgstr "Non vedo l'ora di incontrarti!"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:175
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:216
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:201
+#: lib/tymeslot/emails/templates/calendar_invitation.ex:117
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:102
+#: lib/tymeslot/emails/templates/event_update_notification.ex:210
+#: lib/tymeslot/emails/templates/external_booking_change.class167
+#, elixir-autogen, elixir-format
+msgid "MEETING DETAILS:"
+msgstr "DETTAGLI INCONTRO:"
+
+#: lib/tymeslot/emails/shared/text_body_helper.ex:119
+#, elixir-autogen, elixir-format
+msgid "MESSAGE FROM ATTENDEE:"
+msgstr "MESSAGGIO DAL PARTECIPANTE:"
+
+#: lib/tymeslot/emails/templates/external_booking_change.ex:50
+#: lib/tymeslot/emails/templates/reschedule_request.ex:46
+#: lib/tymeslot/integrations/calendar/utils/ics_generator.ex:69
+#: lib/tymeslot/integrations/calendar/utils/ics_generator.ex:97
+#: lib/tymeslot/integrations/calendar/utils/ics_generator.ex:211
+#, elixir-autogen, elixir-format
+msgid "Meeting"
+msgstr "Incontro"
+
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:127
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:162
+#, elixir-autogen, elixir-format
+msgid "Meeting Cancelled"
+msgstr "Incontro annullato"
+
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:74
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:109
+#, elixir-autogen, elixir-format
+msgid "Meeting Cancelled - %{date} with %{name}"
+msgstr "Incontro annullato - %{date} con %{name}"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:84
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:118
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:125
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:199
+#, elixir-autogen, elixir-format
+msgid "Meeting with %{name}"
+msgstr "Incontro con %{name}"
+
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:134
+#, elixir-autogen, elixir-format
+msgid "Meeting with:"
+msgstr "Incontro con:"
+
+#: lib/tymeslot/integrations/calendar/utils/ics_generator.ex:165
+#, elixir-autogen, elixir-format
+msgid "Message from %{name}:"
+msgstr "Messaggio da %{name}:"
+
+#: lib/tymeslot/emails/shared/text_body_helper.ex:113
+#, elixir-autogen, elixir-format
+msgid "Name:"
+msgstr "Nome:"
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:54
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:162
+#, elixir-autogen, elixir-format
+msgid "Need to change plans?"
+msgstr "Devi cambiare i piani?"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:65
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:118
+#, elixir-autogen, elixir-format
+msgid "Need to make changes?"
+msgstr "Devi apportare modifiche?"
+
+#: lib/tymeslot/emails/appointment_builder.ex:180
+#, elixir-autogen, elixir-format
+msgid "No reminder emails are scheduled for this appointment."
+msgstr "Non sono previste email di promemoria per questo appuntamento."
+
+#: lib/tymeslot/emails/templates/reschedule_request.ex:61
+#: lib/tymeslot/emails/templates/reschedule_request.ex:121
+#, elixir-autogen, elixir-format
+msgid "Once you select a new slot, you'll receive a confirmation email with the updated details. If you have any questions or need to discuss alternative options, please don't hesitate to reach out."
+msgstr "Una volta selezionato un nuovo slot, riceverai un'email di conferma con i dettagli aggiornati. Se hai domande o hai bisogno di discutere opzioni alternative, non esitare a contattarci."
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:178
+#, elixir-autogen, elixir-format
+msgid "QUESTIONS?"
+msgstr "DOMANDE?"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:70
+#, elixir-autogen, elixir-format
+msgid "Questions? %{contact_info}"
+msgstr "Domande? %{contact_info}"
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:154
+#, elixir-autogen, elixir-format
+msgid "REMINDER: Our meeting in %{time_until}"
+msgstr "PROMEMORIA: Il nostro incontro tra %{time_until}"
+
+#: lib/tymeslot/emails/appointment_builder.ex:166
+#, elixir-autogen, elixir-format
+msgid "Reminder %{label} before the appointment."
+msgstr "Promemoria %{label} prima dell'appuntamento."
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:77
+#, elixir-autogen, elixir-format
+msgid "Reminder: Our meeting is %{time_until}"
+msgstr "Promemoria: Il nostro incontro è tra %{time_until}"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:74
+#, elixir-autogen, elixir-format
+msgid "Reminders Scheduled"
+msgstr "Promemoria programmati"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:67
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:120
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:56
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:112
+#: lib/tymeslot/emails/templates/reschedule_request.ex:77
+#, elixir-autogen, elixir-format
+msgid "Reschedule"
+msgstr "Riprogramma"
+
+#: lib/tymeslot/emails/templates/reschedule_request.ex:70
+#: lib/tymeslot/emails/templates/reschedule_request.ex:103
+#, elixir-autogen, elixir-format
+msgid "Reschedule Request"
+msgstr "Richiesta di riprogrammazione"
+
+#: lib/tymeslot/emails/templates/reschedule_request.ex:91
+#, elixir-autogen, elixir-format
+msgid "Reschedule Request: %{title} - %{date}"
+msgstr "Richiesta di riprogrammazione: %{title} - %{date}"
+
+#: lib/tymeslot/emails/shared/text_body_helper.ex:73
+#, elixir-autogen, elixir-format
+msgid "Reschedule:"
+msgstr "Riprogramma:"
+
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:52
+#, elixir-autogen, elixir-format
+msgid "Schedule New Appointment"
+msgstr "Pianifica nuovo appuntamento"
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:58
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:164
+#, elixir-autogen, elixir-format
+msgid "See you %{time_until}!"
+msgstr "Ci vediamo tra %{time_until}!"
+
+#: lib/tymeslot/emails/shared/formatting.ex:187
+#: lib/tymeslot/emails/shared/meeting_components.ex:267
+#, elixir-autogen, elixir-format
+msgid "TBD"
+msgstr "Da definire"
+
+#: lib/tymeslot/emails/templates/reschedule_request.ex:64
+#: lib/tymeslot/emails/templates/reschedule_request.ex:123
+#, elixir-autogen, elixir-format
+msgid "Thank you for your understanding and flexibility."
+msgstr "Grazie per la tua comprensione e flessibilità."
+
+#: lib/tymeslot/emails/shared/text_body_helper.ex:47
+#, elixir-autogen, elixir-format
+msgid "The meeting room opens 5 minutes before your scheduled time."
+msgstr "La sala riunioni apre 5 minuti prima dell'orario programmato."
+
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:54
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:137
+#, elixir-autogen, elixir-format
+msgid "This time slot is now available for booking again."
+msgstr "Questa fascia oraria è ora nuovamente disponibile per la prenotazione."
+
+#: lib/tymeslot/emails/shared/text_body_helper.ex:144
+#: lib/tymeslot/emails/shared/text_body_helper.ex:180
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:104
+#: lib/tymeslot/emails/templates/external_booking_change.ex:169
+#: lib/tymeslot/emails/templates/external_booking_change.ex:193
+#, elixir-autogen, elixir-format
+msgid "Time:"
+msgstr "Ora:"
+
+#: lib/tymeslot/emails/templates/reschedule_request.ex:114
+#, elixir-autogen, elixir-format
+msgid "Timezone:"
+msgstr "Fuso orario:"
+
+#: lib/tymeslot/emails/shared/text_body_helper.ex:152
+#: lib/tymeslot/emails/templates/reschedule_request.ex:113
+#, elixir-autogen, elixir-format
+msgid "Type:"
+msgstr "Tipo:"
+
+#: lib/tymeslot/emails/shared/formatting.ex:185
+#: lib/tymeslot/integrations/calendar/utils/ics_generator.ex:188
+#, elixir-autogen, elixir-format
+msgid "Video Call"
+msgstr "Videochiamata"
+
+#: lib/tymeslot/integrations/calendar/utils/ics_generator.ex:175
+#, elixir-autogen, elixir-format
+msgid "Video meeting:"
+msgstr "Videochiamata:"
+
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:140
+#, elixir-autogen, elixir-format
+msgid "Visit:"
+msgstr "Visita:"
+
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:131
+#, elixir-autogen, elixir-format
+msgid "We're writing to confirm that your appointment has been cancelled."
+msgstr "Ti scriviamo per confermare che il tuo appuntamento è stato annullato."
+
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:51
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:139
+#, elixir-autogen, elixir-format
+msgid "Would you like to schedule a new appointment?"
+msgstr "Vorresti pianificare un nuovo appuntamento?"
+
+#: lib/tymeslot/emails/appointment_builder.ex:231
+#, elixir-autogen, elixir-format
+msgid "You'll receive %{count} reminders before the appointment."
+msgstr "Riceverai %{count} promemoria prima dell'appuntamento."
+
+#: lib/tymeslot/integrations/calendar/utils/ics_generator.ex:163
+#, elixir-autogen, elixir-format
+msgid "attendee"
+msgstr "partecipante"
+
+#: lib/tymeslot/emails/appointment_builder.ex:163
+#: lib/tymeslot/emails/appointment_builder.ex:188
+#: lib/tymeslot/emails/appointment_builder.ex:206
+#: lib/tymeslot/emails/appointment_builder.ex:228
+#, elixir-autogen, elixir-format
+msgid "in %{label}"
+msgstr "tra %{label}"
+
+#: lib/tymeslot/emails/appointment_builder.ex:127
+#, elixir-autogen, elixir-format
+msgid "in 30 minutes"
+msgstr "tra 30 minuti"
+
+#: lib/tymeslot/emails/appointment_builder.ex:273
+#: lib/tymeslot/emails/appointment_builder.ex:276
+#: lib/tymeslot/emails/shared/formatting.ex:265
+#: lib/tymeslot/emails/shared/formatting.ex:280
+#, elixir-autogen, elixir-format
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minuto"
+msgstr[1] "minuti"
+
+#: lib/tymeslot/emails/appointment_builder.ex:112
+#: lib/tymeslot/emails/appointment_builder.ex:125
+#, elixir-autogen, elixir-format
+msgid "reply to this email"
+msgstr "rispondi a questa email"
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:58
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:164
+#: lib/tymeslot_saas/emails/templates/trial_ending_reminder.ex:100
+#, elixir-autogen, elixir-format
+msgid "soon"
+msgstr "presto"
+
+#: lib/tymeslot/emails/shared/text.ex:237
+#, elixir-autogen, elixir-format
+msgid "Having trouble with the button? Copy and paste this link into your browser:"
+msgstr "Hai problemi con il pulsante? Copia e incolla questo link nel tuo browser:"
+
+#: lib/tymeslot/emails/shared/meeting_components.ex:120
+#, elixir-autogen, elixir-format
+msgid "Meeting will start at the scheduled time"
+msgstr "L'incontro inizierà all'orario programmato"
+
+#: lib/tymeslot/emails/appointment_builder.ex:275
+#, elixir-autogen, elixir-format
+msgid "day"
+msgid_plural "days"
+msgstr[0] "giorno"
+msgstr[1] "giorni"
+
+#: dev_support/email_testing/helpers.ex:76
+#: lib/tymeslot/emails/appointment_builder.ex:274
+#: lib/tymeslot/emails/shared/formatting.ex:268
+#: lib/tymeslot/emails/shared/formatting.ex:269
+#: lib/tymeslot/emails/shared/formatting.ex:273
+#: lib/tymeslot/emails/shared/formatting.ex:280
+#, elixir-autogen, elixir-format
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "ora"
+msgstr[1] "ore"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:129
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:214
+#, elixir-autogen, elixir-format
+msgid "%{name} has scheduled a meeting with you."
+msgstr "%{name} ha programmato un incontro con te."
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:235
+#, elixir-autogen, elixir-format
+msgid "- No reminder emails are scheduled for this appointment"
+msgstr "- Non sono previste email di promemoria per questo appuntamento"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:221
+#, elixir-autogen, elixir-format
+msgid "- Prepare an agenda if needed"
+msgstr "- Prepara un ordine del giorno se necessario"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:220
+#, elixir-autogen, elixir-format
+msgid "- Review any relevant materials"
+msgstr "- Rivedi eventuali materiali pertinenti"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:233
+#, elixir-autogen, elixir-format
+msgid "- Set a reminder %{time} before"
+msgstr "- Imposta un promemoria %{time} prima"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:222
+#, elixir-autogen, elixir-format
+msgid "- Test video/audio setup if virtual"
+msgstr "- Testa la configurazione video/audio se virtuale"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:249
+#, elixir-autogen, elixir-format
+msgid "15 minutes"
+msgstr "15 minuti"
+
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:62
+#, elixir-autogen, elixir-format
+msgid "Meeting Details"
+msgstr "Dettagli incontro"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:127
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:212
+#, elixir-autogen, elixir-format
+msgid "New Appointment Booked!"
+msgstr "Nuovo appuntamento prenotato!"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:139
+#, elixir-autogen, elixir-format
+msgid "New Appointment: %{name} - %{date}"
+msgstr "Nuovo appuntamento: %{name} - %{date}"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:219
+#, elixir-autogen, elixir-format
+msgid "PREPARATION REMINDERS:"
+msgstr "PROMEMORIA DI PREPARAZIONE:"
+
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:87
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:164
+#, elixir-autogen, elixir-format
+msgid "The appointment with %{name} has been cancelled."
+msgstr "L'appuntamento con %{name} è stato annullato."
+
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:92
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:170
+#, elixir-autogen, elixir-format
+msgid "The attendee has been notified of the cancellation."
+msgstr "Il partecipante è stato informato dell'annullamento."
+
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:91
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:169
+#, elixir-autogen, elixir-format
+msgid "Your calendar has been updated to reflect this cancellation."
+msgstr "Il tuo calendario è stato aggiornato per riflettere questo annullamento."
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:204
+#, elixir-autogen, elixir-format
+msgid "QUICK PREP:"
+msgstr "PREPARAZIONE RAPIDA:"
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:197
+#, elixir-autogen, elixir-format
+msgid "STARTING IN %{time_until}"
+msgstr "INIZIA TRA %{time_until}"
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:119
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:127
+#, elixir-autogen, elixir-format
+msgid "Starting in %{time_until}"
+msgstr "Inizia tra %{time_until}"
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:207
+#, elixir-autogen, elixir-format
+msgid "• Agenda ready"
+msgstr "• Ordine del giorno pronto"
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:205
+#, elixir-autogen, elixir-format
+msgid "• Camera & mic ready"
+msgstr "• Fotocamera e microfono pronti"
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:205
+#, elixir-autogen, elixir-format
+msgid "• Location confirmed"
+msgstr "• Luogo confermato"
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:206
+#, elixir-autogen, elixir-format
+msgid "• Materials prepared"
+msgstr "• Materiali preparati"
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:135
+#, elixir-autogen, elixir-format
+msgid "⏰ Meeting with %{name} in %{time_until}"
+msgstr "⏰ Incontro con %{name} tra %{time_until}"
+
+#: lib/tymeslot/emails/shared/formatting.ex:186
+#, elixir-autogen, elixir-format
+msgid "Phone Call"
+msgstr "Telefonata"
+
+#: lib/tymeslot/emails/templates/calendar_invitation.ex:60
+#: lib/tymeslot/emails/templates/calendar_invitation.ex:115
+#, elixir-autogen, elixir-format
+msgid "%{name} has invited you to an event."
+msgstr "%{name} ti ha invitato a un evento."
+
+#: lib/tymeslot/emails/templates/calendar_invitation.ex:84
+#, elixir-autogen, elixir-format
+msgid "Calendar Invitation - %{title} on %{date}"
+msgstr "Invito calendario - %{title} il %{date}"
+
+#: lib/tymeslot/emails/templates/calendar_invitation.ex:58
+#: lib/tymeslot/emails/templates/calendar_invitation.ex:113
+#, elixir-autogen, elixir-format
+msgid "You're Invited"
+msgstr "Sei invitato"
+
+#: lib/tymeslot/emails/templates/event_update_notification.ex:77
+#: lib/tymeslot/emails/templates/event_update_notification.ex:208
+#, elixir-autogen, elixir-format
+msgid "%{name} has updated an event you're attending."
+msgstr "%{name} ha aggiornato un evento a cui partecipi."
+
+#: lib/tymeslot/emails/shared/text_body_helper.ex:168
+#: lib/tymeslot/emails/shared/text_body_helper.ex:172
+#: lib/tymeslot/emails/templates/event_update_notification.ex:196
+#, elixir-autogen, elixir-format
+msgid "(none)"
+msgstr "(nessuno)"
+
+#: lib/tymeslot/emails/shared/text_body_helper.ex:176
+#, elixir-autogen, elixir-format
+msgid "Description updated"
+msgstr "Descrizione aggiornata"
+
+#: lib/tymeslot/emails/templates/event_update_notification.ex:206
+#, elixir-autogen, elixir-format
+msgid "Event Updated"
+msgstr "Evento aggiornato"
+
+#: lib/tymeslot/emails/shared/text_body_helper.ex:168
+#, elixir-autogen, elixir-format
+msgid "Title:"
+msgstr "Titolo:"
+
+#: lib/tymeslot/emails/templates/event_update_notification.ex:101
+#, elixir-autogen, elixir-format
+msgid "Updated: %{title} — %{date}"
+msgstr "Aggiornato: %{title} — %{date}"
+
+#: lib/tymeslot/emails/templates/event_update_notification.ex:213
+#, elixir-autogen, elixir-format
+msgid "What Changed"
+msgstr "Cosa è cambiato"
+
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:105
+#, elixir-autogen, elixir-format
+msgid "%{count} minutes"
+msgstr "%{count} minuti"
+
+#: lib/tymeslot/emails/templates/email_change_notification.ex:43
+#, elixir-autogen, elixir-format
+msgid "A change was requested on your Tymeslot account."
+msgstr "È stata richiesta una modifica al tuo account Tymeslot."
+
+#: lib/tymeslot/emails/templates/password_reset.ex:38
+#, elixir-autogen, elixir-format
+msgid "A fresh password and you're back in."
+msgstr "Una nuova password e sei di nuovo dentro."
+
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:87
+#, elixir-autogen, elixir-format
+msgid "A meeting could not be added to your calendar."
+msgstr "Non è stato possibile aggiungere un incontro al tuo calendario."
+
+#: lib/tymeslot/emails/templates/email_change_notification.ex:31
+#: lib/tymeslot/emails/templates/email_change_notification.ex:70
+#, elixir-autogen, elixir-format
+msgid "A verification email has been sent to the new address"
+msgstr "Un'email di verifica è stata inviata al nuovo indirizzo"
+
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:111
+#, elixir-autogen, elixir-format
+msgid "ACTION REQUIRED:"
+msgstr "AZIONE RICHIESTA:"
+
+#: lib/tymeslot/emails/templates/password_reset.ex:33
+#, elixir-autogen, elixir-format
+msgid "Account Security"
+msgstr "Sicurezza account"
+
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:63
+#, elixir-autogen, elixir-format
+msgid "Account Update"
+msgstr "Aggiornamento account"
+
+#: lib/tymeslot/emails/templates/email_verification.ex:32
+#, elixir-autogen, elixir-format
+msgid "Account Verification"
+msgstr "Verifica account"
+
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:71
+#, elixir-autogen, elixir-format
+msgid "Action Required"
+msgstr "Azione richiesta"
+
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:89
+#: lib/tymeslot/emails/templates/external_booking_change.ex:94
+#, elixir-autogen, elixir-format
+msgid "Action required"
+msgstr "Azione richiesta"
+
+#: lib/tymeslot/emails/templates/external_booking_change.ex:216
+#, elixir-autogen, elixir-format
+msgid "Action required: \"%{title}\" was deleted from your external calendar (%{date})"
+msgstr "Azione richiesta: \"%{title}\" è stato eliminato dal tuo calendario esterno (%{date})"
+
+#: lib/tymeslot/emails/templates/external_booking_change.ex:225
+#, elixir-autogen, elixir-format
+msgid "Action required: \"%{title}\" was rescheduled in your external calendar (%{date})"
+msgstr "Azione richiesta: \"%{title}\" è stato riprogrammato nel tuo calendario esterno (%{date})"
+
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:43
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:121
+#, elixir-autogen, elixir-format
+msgid "Active"
+msgstr "Attivo"
+
+#: lib/tymeslot/emails/shared/meeting_components.ex:441
+#, elixir-autogen, elixir-format
+msgid "Add to your calendar"
+msgstr "Aggiungi al tuo calendario"
+
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:47
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:125
+#, elixir-autogen, elixir-format
+msgid "All future emails will be sent to your new address"
+msgstr "Tutte le email future verranno inviate al tuo nuovo indirizzo"
+
+#: lib/tymeslot/emails/shared/meeting_components.ex:480
+#, elixir-autogen, elixir-format
+msgid "Attendee Information"
+msgstr "Informazioni partecipante"
+
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:117
+#, elixir-autogen, elixir-format
+msgid "CHANGE DETAILS:"
+msgstr "DETTAGLI MODIFICA:"
+
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:115
+#, elixir-autogen, elixir-format
+msgid "CalDAV server temporarily unavailable"
+msgstr "Server CalDAV temporaneamente non disponibile"
+
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:60
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:86
+#, elixir-autogen, elixir-format
+msgid "Calendar Sync Error"
+msgstr "Errore sincronizzazione calendario"
+
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:98
+#, elixir-autogen, elixir-format
+msgid "Calendar Sync Error — Manual Action Required"
+msgstr "Errore sincronizzazione calendario — Azione manuale richiesta"
+
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:90
+#, elixir-autogen, elixir-format
+msgid "Calendar didn't sync"
+msgstr "Il calendario non si è sincronizzato"
+
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:117
+#, elixir-autogen, elixir-format
+msgid "Calendar permissions or authentication problems"
+msgstr "Problemi di permessi o autenticazione del calendario"
+
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:61
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:98
+#, elixir-autogen, elixir-format
+msgid "Cancelled"
+msgstr "Annullato"
+
+#: lib/tymeslot/emails/templates/integration_unhealthy.ex:59
+#, elixir-autogen, elixir-format
+msgid "Check Integration Settings"
+msgstr "Controlla impostazioni integrazione"
+
+#: lib/tymeslot/emails/templates/integration_unhealthy.ex:112
+#, elixir-autogen, elixir-format
+msgid "Check Integration Settings:"
+msgstr "Controlla impostazioni integrazione:"
+
+#: lib/tymeslot/emails/templates/integration_unhealthy.ex:53
+#: lib/tymeslot/emails/templates/integration_unhealthy.ex:108
+#, elixir-autogen, elixir-format
+msgid "Check that your credentials or OAuth tokens are still valid"
+msgstr "Controlla che le tue credenziali o i token OAuth siano ancora validi"
+
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:114
+#, elixir-autogen, elixir-format
+msgid "Common causes:"
+msgstr "Cause comuni:"
+
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:78
+#, elixir-autogen, elixir-format
+msgid "Common causes:<br/>• CalDAV server temporarily unavailable<br/>• Network connectivity issues<br/>• Calendar permissions or authentication problems<br/>• Maximum retries exceeded"
+msgstr "Cause comuni:<br/>• Server CalDAV temporaneamente non disponibile<br/>• Problemi di connettività di rete<br/>• Problemi di permessi o autenticazione del calendario<br/>• Numero massimo di tentativi superato"
+
+#: lib/tymeslot/emails/shared/meeting_components.ex:486
+#, elixir-autogen, elixir-format
+msgid "Company"
+msgstr "Azienda"
+
+#: lib/tymeslot/emails/templates/email_verification.ex:21
+#, elixir-autogen, elixir-format
+msgid "Confirm Email & Get Started"
+msgstr "Conferma email e inizia"
+
+#: lib/tymeslot/emails/templates/email_verification.ex:52
+#, elixir-autogen, elixir-format
+msgid "Confirm Email & Get Started:"
+msgstr "Conferma email e inizia:"
+
+#: lib/tymeslot/emails/templates/email_change_verification.ex:49
+#, elixir-autogen, elixir-format
+msgid "Confirm the new email address on your Tymeslot account."
+msgstr "Conferma il nuovo indirizzo email sul tuo account Tymeslot."
+
+#: lib/tymeslot/emails/templates/email_change_verification.ex:52
+#, elixir-autogen, elixir-format
+msgid "Confirm your new email"
+msgstr "Conferma la tua nuova email"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:81
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:66
+#, elixir-autogen, elixir-format
+msgid "Confirmed"
+msgstr "Confermato"
+
+#: lib/tymeslot/emails/templates/integration_unhealthy.ex:55
+#: lib/tymeslot/emails/templates/integration_unhealthy.ex:110
+#, elixir-autogen, elixir-format
+msgid "Contact your %{type} provider if the issue persists"
+msgstr "Contatta il tuo fornitore di %{type} se il problema persiste"
+
+#: lib/tymeslot/emails/templates/email_change_verification.ex:38
+#: lib/tymeslot/emails/templates/email_change_verification.ex:107
+#, elixir-autogen, elixir-format
+msgid "Didn't request this change? You can safely ignore this email — nothing will happen to your account."
+msgstr "Non hai richiesto questa modifica? Puoi ignorare tranquillamente questa email — non accadrà nulla al tuo account."
+
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:108
+#, elixir-autogen, elixir-format
+msgid "ERROR DETAILS:"
+msgstr "DETTAGLI ERRORE:"
+
+#: lib/tymeslot/emails/shared/meeting_components.ex:578
+#, elixir-autogen, elixir-format
+msgid "Email"
+msgstr "Email"
+
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:67
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:113
+#, elixir-autogen, elixir-format
+msgid "Email change complete"
+msgstr "Modifica email completata"
+
+#: lib/tymeslot/emails/templates/email_change_notification.ex:46
+#: lib/tymeslot/emails/templates/email_change_notification.ex:57
+#, elixir-autogen, elixir-format
+msgid "Email change requested"
+msgstr "Richiesta modifica email"
+
+#: lib/tymeslot/emails/templates/email_change_notification.ex:25
+#, elixir-autogen, elixir-format
+msgid "Email change requested to: %{new_email}"
+msgstr "Richiesta modifica email a: %{new_email}"
+
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:69
+#, elixir-autogen, elixir-format
+msgid "Error"
+msgstr "Errore"
+
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:67
+#, elixir-autogen, elixir-format
+msgid "Error Details"
+msgstr "Dettagli errore"
+
+#: lib/tymeslot/emails/templates/event_update_notification.ex:75
+#, elixir-autogen, elixir-format
+msgid "Event updated"
+msgstr "Evento aggiornato"
+
+#: lib/tymeslot/emails/templates/email_verification.ex:55
+#, elixir-autogen, elixir-format
+msgid "For your security, this link expires in 24 hours. If you didn't sign up for Tymeslot, no further action is needed."
+msgstr "Per la tua sicurezza, questo link scade tra 24 ore. Se non ti sei iscritto a Tymeslot, non è richiesta alcuna azione."
+
+#: lib/tymeslot/emails/templates/email_verification.ex:23
+#, elixir-autogen, elixir-format
+msgid "For your security, this link expires in 24 hours. If you didn't sign up for Tymeslot, you can ignore this email."
+msgstr "Per la tua sicurezza, questo link scade tra 24 ore. Se non ti sei iscritto a Tymeslot, puoi ignorare questa email."
+
+#: lib/tymeslot/emails/shared/formatting.ex:244
+#, elixir-autogen, elixir-format
+msgid "Friday"
+msgstr "Venerdì"
+
+#: lib/tymeslot/emails/templates/email_change_verification.ex:34
+#, elixir-autogen, elixir-format
+msgid "Heads up"
+msgstr "Attenzione"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:48
+#, elixir-autogen, elixir-format
+msgid "Hi %{name} — I've blocked the time on my calendar and I'm looking forward to our meeting."
+msgstr "Ciao %{name} — ho bloccato l'orario sul mio calendario e non vedo l'ora del nostro incontro."
+
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:47
+#, elixir-autogen, elixir-format
+msgid "Hi %{name} — our appointment has been cancelled. I'm sorry for the inconvenience."
+msgstr "Ciao %{name} — il nostro appuntamento è stato annullato. Mi dispiace per l'inconveniente."
+
+#: lib/tymeslot/emails/templates/reschedule_request.ex:80
+#, elixir-autogen, elixir-format
+msgid "Hi %{name}, I need to reschedule our upcoming meeting."
+msgstr "Ciao %{name}, ho bisogno di riprogrammare il nostro prossimo incontro."
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:106
+#, elixir-autogen, elixir-format
+msgid "Host video call"
+msgstr "Avvia videochiamata"
+
+#: lib/tymeslot/emails/templates/reschedule_request.ex:55
+#, elixir-autogen, elixir-format
+msgid "I apologise for any inconvenience this may cause. Your current appointment has been cancelled, and I'd like to help you reschedule at your earliest convenience."
+msgstr "Mi scuso per l'inconveniente. Il tuo appuntamento attuale è stato annullato e vorrei aiutarti a riprogrammarlo al più presto."
+
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:58
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:100
+#, elixir-autogen, elixir-format
+msgid "I was unable to add this meeting to your calendar. The appointment has been successfully confirmed in Tymeslot and both you and the attendee have received confirmation emails. However, you'll need to manually add it to your calendar."
+msgstr "Non è stato possibile aggiungere questo incontro al tuo calendario. L'appuntamento è stato confermato con successo in Tymeslot e sia tu che il partecipante avete ricevuto le email di conferma. Tuttavia, dovrai aggiungerlo manualmente al tuo calendario."
+
+#: lib/tymeslot/emails/templates/external_booking_change.ex:173
+#, elixir-autogen, elixir-format
+msgid "If the meeting is no longer happening, please cancel it in Tymeslot so the attendee is notified and the time slot is freed up."
+msgstr "Se l'incontro non si terrà più, annullalo in Tymeslot in modo che il partecipante venga informato e la fascia oraria venga liberata."
+
+#: lib/tymeslot/emails/templates/external_booking_change.ex:197
+#, elixir-autogen, elixir-format
+msgid "If the new time is final, please update or reschedule the booking in Tymeslot so the attendee receives updated details."
+msgstr "Se il nuovo orario è definitivo, aggiorna o riprogramma la prenotazione in Tymeslot in modo che il partecipante riceva i dettagli aggiornati."
+
+#: lib/tymeslot/emails/templates/integration_unhealthy.ex:54
+#: lib/tymeslot/emails/templates/integration_unhealthy.ex:109
+#, elixir-autogen, elixir-format
+msgid "If you changed your password recently, you may need to reconnect the integration"
+msgstr "Se hai cambiato la password di recente, potresti dover ricollegare l'integrazione"
+
+#: lib/tymeslot/emails/templates/password_reset.ex:24
+#: lib/tymeslot/emails/templates/password_reset.ex:58
+#, elixir-autogen, elixir-format
+msgid "If you didn't request this change, your account is still secure — you can simply delete this email."
+msgstr "Se non hai richiesto questa modifica, il tuo account è ancora al sicuro — puoi semplicemente eliminare questa email."
+
+#: lib/tymeslot/emails/templates/password_reset.ex:34
+#, elixir-autogen, elixir-format
+msgid "Instructions to reset your Tymeslot password."
+msgstr "Istruzioni per reimpostare la tua password Tymeslot."
+
+#: lib/tymeslot/emails/templates/integration_unhealthy.ex:74
+#, elixir-autogen, elixir-format
+msgid "Integration"
+msgstr "Integrazione"
+
+#: lib/tymeslot/emails/templates/integration_unhealthy.ex:32
+#: lib/tymeslot/emails/templates/integration_unhealthy.ex:68
+#: lib/tymeslot/emails/templates/integration_unhealthy.ex:99
+#, elixir-autogen, elixir-format
+msgid "Integration Connection Issues"
+msgstr "Problemi di connessione dell'integrazione"
+
+#: lib/tymeslot/emails/templates/integration_unhealthy.ex:75
+#, elixir-autogen, elixir-format
+msgid "Integration needs attention"
+msgstr "L'integrazione richiede attenzione"
+
+#: lib/tymeslot/emails/templates/calendar_invitation.ex:57
+#, elixir-autogen, elixir-format
+msgid "Invited"
+msgstr "Invitato"
+
+#: lib/tymeslot/emails/templates/password_reset.ex:51
+#, elixir-autogen, elixir-format
+msgid "It happens to the best of us! Click the link below to choose a new password and regain access to your account."
+msgstr "Succede ai migliori! Clicca sul link qui sotto per scegliere una nuova password e riottenere l'accesso al tuo account."
+
+#: lib/tymeslot/emails/templates/password_reset.ex:19
+#, elixir-autogen, elixir-format
+msgid "It happens to the best of us. Click the button below to choose a new password and pick up where you left off."
+msgstr "Succede ai migliori. Clicca sul pulsante qui sotto per scegliere una nuova password e riprendere da dove avevi lasciato."
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:50
+#, elixir-autogen, elixir-format
+msgid "Join when you're ready"
+msgstr "Partecipa quando sei pronto"
+
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:132
+#: lib/tymeslot/emails/templates/email_change_notification.ex:79
+#, elixir-autogen, elixir-format
+msgid "Just now"
+msgstr "Adesso"
+
+#: lib/tymeslot/emails/templates/reschedule_request.ex:78
+#, elixir-autogen, elixir-format
+msgid "Let's find a new time"
+msgstr "Troviamo un nuovo orario"
+
+#: lib/tymeslot/emails/templates/email_verification.ex:37
+#, elixir-autogen, elixir-format
+msgid "Let's get you scheduling in under a minute."
+msgstr "Iniziamo a pianificare in meno di un minuto."
+
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:118
+#, elixir-autogen, elixir-format
+msgid "Maximum retries exceeded"
+msgstr "Numero massimo di tentativi superato"
+
+#: lib/tymeslot/emails/templates/external_booking_change.ex:112
+#: lib/tymeslot/emails/templates/external_booking_change.ex:163
+#, elixir-autogen, elixir-format
+msgid "Meeting Deleted in External Calendar"
+msgstr "Incontro eliminato nel calendario esterno"
+
+#: lib/tymeslot/emails/templates/external_booking_change.ex:126
+#: lib/tymeslot/emails/templates/external_booking_change.ex:187
+#, elixir-autogen, elixir-format
+msgid "Meeting Rescheduled in External Calendar"
+msgstr "Incontro riprogrammato nel calendario esterno"
+
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:62
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:99
+#, elixir-autogen, elixir-format
+msgid "Meeting cancelled"
+msgstr "Incontro annullato"
+
+#: lib/tymeslot/emails/shared/meeting_components.ex:342
+#, elixir-autogen, elixir-format
+msgid "Meeting type"
+msgstr "Tipo di incontro"
+
+#: lib/tymeslot/emails/shared/meeting_components.ex:529
+#, elixir-autogen, elixir-format
+msgid "Message from attendee"
+msgstr "Messaggio dal partecipante"
+
+#: lib/tymeslot/emails/shared/formatting.ex:240
+#, elixir-autogen, elixir-format
+msgid "Monday"
+msgstr "Lunedì"
+
+#: lib/tymeslot/emails/shared/meeting_components.ex:483
+#, elixir-autogen, elixir-format
+msgid "Name"
+msgstr "Nome"
+
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:116
+#, elixir-autogen, elixir-format
+msgid "Network connectivity issues"
+msgstr "Problemi di connettività di rete"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:126
+#, elixir-autogen, elixir-format
+msgid "New booking"
+msgstr "Nuova prenotazione"
+
+#: lib/tymeslot/emails/templates/email_change_verification.ex:77
+#, elixir-autogen, elixir-format
+msgid "New email address"
+msgstr "Nuovo indirizzo email"
+
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:106
+#: lib/tymeslot/emails/templates/external_booking_change.ex:171
+#: lib/tymeslot/emails/templates/external_booking_change.ex:195
+#, elixir-autogen, elixir-format
+msgid "Not specified"
+msgstr "Non specificato"
+
+#: lib/tymeslot/emails/templates/external_booking_change.ex:191
+#, elixir-autogen, elixir-format
+msgid "ORIGINAL BOOKING DETAILS:"
+msgstr "DETTAGLI PRENOTAZIONE ORIGINALE:"
+
+#: lib/tymeslot/emails/templates/email_change_verification.ex:53
+#, elixir-autogen, elixir-format
+msgid "One click and the switch is done."
+msgstr "Un click e il cambio è fatto."
+
+#: lib/tymeslot/emails/templates/integration_unhealthy.ex:28
+#: lib/tymeslot/emails/templates/integration_unhealthy.ex:101
+#, elixir-autogen, elixir-format
+msgid "One of your %{type} integrations (%{provider}) has been reporting connection issues for over 48 hours. You may want to check your integration settings."
+msgstr "Una delle tue integrazioni %{type} (%{provider}) segnala problemi di connessione da oltre 48 ore. Potresti voler controllare le impostazioni della tua integrazione."
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:65
+#, elixir-autogen, elixir-format
+msgid "Our meeting is coming up"
+msgstr "Il nostro incontro si avvicina"
+
+#: lib/tymeslot/emails/shared/meeting_components.ex:485
+#, elixir-autogen, elixir-format
+msgid "Phone"
+msgstr "Telefono"
+
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:74
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:112
+#, elixir-autogen, elixir-format
+msgid "Please manually add this meeting to your calendar to ensure you don't miss it. Both you and the attendee have already received your confirmation emails — this is purely a technical calendar sync issue that doesn't affect the booking itself."
+msgstr "Aggiungi manualmente questo incontro al tuo calendario per assicurarti di non perderlo. Sia tu che il partecipante avete già ricevuto le email di conferma — questo è puramente un problema tecnico di sincronizzazione del calendario che non influisce sulla prenotazione stessa."
+
+#: lib/tymeslot/emails/templates/external_booking_change.ex:96
+#, elixir-autogen, elixir-format
+msgid "Please review and update the booking in Tymeslot."
+msgstr "Controlla e aggiorna la prenotazione in Tymeslot."
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:110
+#, elixir-autogen, elixir-format
+msgid "Quick actions"
+msgstr "Azioni rapide"
+
+#: lib/tymeslot/emails/templates/email_change_notification.ex:63
+#, elixir-autogen, elixir-format
+msgid "REQUEST DETAILS:"
+msgstr "DETTAGLI RICHIESTA:"
+
+#: lib/tymeslot/emails/templates/appointment_confirmation.ex:61
+#, elixir-autogen, elixir-format
+msgid "Ready to join when it's time?"
+msgstr "Pronto a partecipare quando sarà il momento?"
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:64
+#, elixir-autogen, elixir-format
+msgid "Reminder"
+msgstr "Promemoria"
+
+#: lib/tymeslot/emails/templates/password_reset.ex:47
+#, elixir-autogen, elixir-format
+msgid "Reset Your Password"
+msgstr "Reimposta la tua password"
+
+#: lib/tymeslot/emails/templates/password_reset.ex:37
+#, elixir-autogen, elixir-format
+msgid "Reset your password"
+msgstr "Reimposta la tua password"
+
+#: lib/tymeslot/emails/shared/formatting.ex:245
+#, elixir-autogen, elixir-format
+msgid "Saturday"
+msgstr "Sabato"
+
+#: lib/tymeslot/emails/templates/email_change_notification.ex:45
+#: lib/tymeslot/emails/templates/password_reset.ex:36
+#, elixir-autogen, elixir-format
+msgid "Security"
+msgstr "Sicurezza"
+
+#: lib/tymeslot/emails/templates/password_reset.ex:21
+#, elixir-autogen, elixir-format
+msgid "Set New Password"
+msgstr "Imposta nuova password"
+
+#: lib/tymeslot/emails/templates/password_reset.ex:53
+#, elixir-autogen, elixir-format
+msgid "Set New Password:"
+msgstr "Imposta nuova password:"
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:107
+#, elixir-autogen, elixir-format
+msgid "Start Meeting"
+msgstr "Inizia incontro"
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:67
+#, elixir-autogen, elixir-format
+msgid "Starting %{time_until}"
+msgstr "Inizia tra %{time_until}"
+
+#: lib/tymeslot/emails/templates/appointment_reminder.ex:123
+#, elixir-autogen, elixir-format
+msgid "Starting soon"
+msgstr "Inizia a breve"
+
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:121
+#: lib/tymeslot/emails/templates/email_change_notification.ex:67
+#, elixir-autogen, elixir-format
+msgid "Status:"
+msgstr "Stato:"
+
+#: lib/tymeslot/emails/shared/formatting.ex:246
+#, elixir-autogen, elixir-format
+msgid "Sunday"
+msgstr "Domenica"
+
+#: lib/tymeslot/emails/templates/calendar_sync_error.ex:92
+#, elixir-autogen, elixir-format
+msgid "The booking is safe — but please add it to your calendar manually."
+msgstr "La prenotazione è sicura — ma aggiungila manualmente al tuo calendario."
+
+#: lib/tymeslot/emails/templates/email_change_notification.ex:31
+#: lib/tymeslot/emails/templates/email_change_notification.ex:73
+#, elixir-autogen, elixir-format
+msgid "Your current email remains active until the change is confirmed"
+msgstr "La tua email attuale rimane attiva finché la modifica non viene confermata"
+
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:47
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:126
+#, elixir-autogen, elixir-format
+msgid "Your meetings and settings remain unchanged"
+msgstr "I tuoi incontri e le tue impostazioni rimangono invariati"
+
+#: lib/tymeslot/emails/templates/integration_unhealthy.ex:128
+#, elixir-autogen, elixir-format
+msgid "calendar"
+msgstr "calendario"
+
+#: lib/tymeslot/emails/templates/integration_unhealthy.ex:129
+#, elixir-autogen, elixir-format
+msgid "video"
+msgstr "video"
+
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:64
+#: lib/tymeslot/emails/templates/appointment_cancellation.ex:101
+#, elixir-autogen, elixir-format
+msgid "with %{name}"
+msgstr "con %{name}"
+
+#: lib/tymeslot/emails/templates/event_update_notification.ex:186
+#, elixir-autogen, elixir-format
+msgid "(previous)"
+msgstr "(precedente)"
+
+#: lib/tymeslot/emails/templates/event_update_notification.ex:187
+#, elixir-autogen, elixir-format
+msgid "(updated)"
+msgstr "(aggiornato)"
+
+#: lib/tymeslot/emails/templates/event_update_notification.ex:168
+#, elixir-autogen, elixir-format
+msgid "After"
+msgstr "Dopo"
+
+#: lib/tymeslot/emails/templates/event_update_notification.ex:167
+#, elixir-autogen, elixir-format
+msgid "Before"
+msgstr "Prima"
+
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:43
+#, elixir-autogen, elixir-format
+msgid "Change details"
+msgstr "Dettagli modifica"
+
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:43
+#, elixir-autogen, elixir-format
+msgid "Changed at"
+msgstr "Modificato il"
+
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:120
+#, elixir-autogen, elixir-format
+msgid "Changed at:"
+msgstr "Modificato il:"
+
+#: lib/tymeslot/emails/templates/email_change_notification.ex:27
+#, elixir-autogen, elixir-format
+msgid "Current email"
+msgstr "Email attuale"
+
+#: lib/tymeslot/emails/templates/email_change_notification.ex:65
+#, elixir-autogen, elixir-format
+msgid "Current email:"
+msgstr "Email attuale:"
+
+#: lib/tymeslot/emails/templates/event_update_notification.ex:186
+#, elixir-autogen, elixir-format
+msgid "Description"
+msgstr "Descrizione"
+
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:52
+#, elixir-autogen, elixir-format
+msgid "Didn't expect this?"
+msgstr "Non te lo aspettavi?"
+
+#: lib/tymeslot/emails/templates/email_change_notification.ex:35
+#, elixir-autogen, elixir-format
+msgid "Didn't request this?"
+msgstr "Non l'hai richiesto?"
+
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:41
+#, elixir-autogen, elixir-format
+msgid "Email change completed successfully."
+msgstr "Modifica email completata con successo."
+
+#: lib/tymeslot/emails/templates/event_update_notification.ex:166
+#, elixir-autogen, elixir-format
+msgid "Field"
+msgstr "Campo"
+
+#: lib/tymeslot/emails/templates/email_change_notification.ex:19
+#: lib/tymeslot/emails/templates/email_change_notification.ex:59
+#, elixir-autogen, elixir-format
+msgid "Hi %{name}, a request has been made to change the email address on your Tymeslot account. We're letting you know so you can confirm it was you."
+msgstr "Ciao %{name}, è stata effettuata una richiesta per modificare l'indirizzo email del tuo account Tymeslot. Ti informiamo in modo che tu possa confermare che sei stato tu."
+
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:31
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:90
+#, elixir-autogen, elixir-format
+msgid "Hi %{name}, your Tymeslot account email address has been successfully changed."
+msgstr "Ciao %{name}, l'indirizzo email del tuo account Tymeslot è stato modificato con successo."
+
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:25
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:84
+#, elixir-autogen, elixir-format
+msgid "Hi %{name}, your Tymeslot account email address has been successfully changed. This confirmation is being sent to your previous address so you know the switch happened."
+msgstr "Ciao %{name}, l'indirizzo email del tuo account Tymeslot è stato modificato con successo. Questa conferma viene inviata al tuo indirizzo precedente per informarti dell'avvenuto cambio."
+
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:51
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:100
+#, elixir-autogen, elixir-format
+msgid "If you did not authorise this change, please contact support immediately. You will no longer receive emails at this address."
+msgstr "Se non hai autorizzato questa modifica, contatta immediatamente il supporto. Non riceverai più email a questo indirizzo."
+
+#: lib/tymeslot/emails/templates/email_change_notification.ex:34
+#: lib/tymeslot/emails/templates/email_change_notification.ex:75
+#, elixir-autogen, elixir-format
+msgid "If you did not request this change, your account may be compromised. Please sign in to your account immediately and change your password."
+msgstr "Se non hai richiesto questa modifica, il tuo account potrebbe essere compromesso. Accedi immediatamente al tuo account e cambia la password."
+
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:43
+#: lib/tymeslot/emails/templates/email_change_notification.ex:27
+#, elixir-autogen, elixir-format
+msgid "New email"
+msgstr "Nuova email"
+
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:119
+#: lib/tymeslot/emails/templates/email_change_notification.ex:64
+#, elixir-autogen, elixir-format
+msgid "New email:"
+msgstr "Nuova email:"
+
+#: lib/tymeslot/emails/templates/email_change_notification.ex:27
+#: lib/tymeslot/emails/templates/email_change_notification.ex:67
+#, elixir-autogen, elixir-format
+msgid "Pending verification"
+msgstr "In attesa di verifica"
+
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:43
+#, elixir-autogen, elixir-format
+msgid "Previous email"
+msgstr "Email precedente"
+
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:118
+#, elixir-autogen, elixir-format
+msgid "Previous email:"
+msgstr "Email precedente:"
+
+#: lib/tymeslot/emails/templates/email_change_notification.ex:27
+#, elixir-autogen, elixir-format
+msgid "Request details"
+msgstr "Dettagli richiesta"
+
+#: lib/tymeslot/emails/templates/email_change_notification.ex:27
+#, elixir-autogen, elixir-format
+msgid "Requested at"
+msgstr "Richiesto il"
+
+#: lib/tymeslot/emails/templates/email_change_notification.ex:66
+#, elixir-autogen, elixir-format
+msgid "Requested at:"
+msgstr "Richiesto il:"
+
+#: lib/tymeslot/emails/templates/email_change_notification.ex:42
+#, elixir-autogen, elixir-format
+msgid "Security notification"
+msgstr "Notifica di sicurezza"
+
+#: lib/tymeslot/emails/shared/mjml_email.ex:277
+#, elixir-autogen, elixir-format
+msgid "Sent with care by"
+msgstr "Inviato con cura da"
+
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:43
+#: lib/tymeslot/emails/templates/email_change_notification.ex:27
+#, elixir-autogen, elixir-format
+msgid "Status"
+msgstr "Stato"
+
+#: lib/tymeslot/emails/templates/event_update_notification.ex:191
+#, elixir-autogen, elixir-format
+msgid "Time"
+msgstr "Ora"
+
+#: lib/tymeslot/emails/templates/event_update_notification.ex:179
+#, elixir-autogen, elixir-format
+msgid "Title"
+msgstr "Titolo"
+
+#: lib/tymeslot/emails/templates/event_update_notification.ex:162
+#, elixir-autogen, elixir-format
+msgid "What changed"
+msgstr "Cosa è cambiato"
+
+#: lib/tymeslot/emails/templates/email_change_notification.ex:29
+#, elixir-autogen, elixir-format
+msgid "What happens next"
+msgstr "Cosa succede ora"
+
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:45
+#, elixir-autogen, elixir-format
+msgid "What you need to know"
+msgstr "Cosa devi sapere"
+
+#: dev_support/email_testing/helpers.ex:77
+#, elixir-autogen, elixir-format
+msgid "in %{time_until}"
+msgstr "tra %{time_until}"
+
+#: lib/tymeslot/emails/shared/layouts.ex:156
+#: lib/tymeslot/emails/shared/mjml_email.ex:279
+#, elixir-autogen, elixir-format
+msgid "scheduling that respects your time"
+msgstr "pianificazione che rispetta il tuo tempo"
+
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:55
+#: lib/tymeslot/emails/templates/email_change_confirmed.ex:106
+#, elixir-autogen, elixir-format
+msgid "For security, a copy of this confirmation was sent to your previous email address."
+msgstr "Per sicurezza, una copia di questa conferma è stata inviata al tuo precedente indirizzo email."
+
+#: dev_support/email_testing/helpers.ex:80
+#, elixir-autogen, elixir-format
+msgid "I'll send you a reminder 24 hours before our appointment."
+msgstr "Ti invierò un promemoria 24 ore prima del nostro appuntamento."
+
+#: lib/tymeslot_saas/emails/templates/trial_ending_reminder.ex:126
+#, elixir-autogen, elixir-format
+msgid "in %{count} day"
+msgid_plural "in %{count} days"
+msgstr[0] "tra %{count} giorno"
+msgstr[1] "tra %{count} giorni"
+
+#: lib/tymeslot_saas/emails/templates/trial_ending_reminder.ex:115
+#, elixir-autogen, elixir-format
+msgid "in %{count} hour"
+msgid_plural "in %{count} hours"
+msgstr[0] "tra %{count} ora"
+msgstr[1] "tra %{count} ore"
+
+#: lib/tymeslot_saas/emails/templates/trial_ending_reminder.ex:132
+#, elixir-autogen, elixir-format
+msgid "today"
+msgstr "oggi"
+
+#: lib/tymeslot_saas/emails/templates/trial_ending_reminder.ex:129
+#, elixir-autogen, elixir-format
+msgid "tomorrow"
+msgstr "domani"

--- a/priv/gettext/it/LC_MESSAGES/errors.po
+++ b/priv/gettext/it/LC_MESSAGES/errors.po
@@ -1,0 +1,49 @@
+msgid ""
+msgstr ""
+"Language: it\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Project-Id-Version: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+
+#: Error Messages
+msgid "something_went_wrong"
+msgstr "qualcosa è andato storto"
+
+msgid "try_again_later"
+msgstr "riprova più tardi"
+
+msgid "invalid_meeting_link"
+msgstr "link dell'appuntamento non valido"
+
+msgid "slot_no_longer_available"
+msgstr "lo slot non è più disponibile"
+
+msgid "name_required"
+msgstr "nome obbligatorio"
+
+msgid "email_required"
+msgstr "email obbligatoria"
+
+msgid "email_invalid"
+msgstr "email non valida"
+
+#: lib/tymeslot_web/themes/shared/components/error_component.ex:31
+#, elixir-autogen
+msgid "calendar_setup_required"
+msgstr "configurazione del calendario richiesta"
+
+#: lib/tymeslot_web/themes/shared/components/error_component.ex:44
+#, elixir-autogen
+msgid "connect_calendar_first"
+msgstr "collega prima il calendario"
+
+#: Status
+msgid "loading"
+msgstr "caricamento..."
+
+msgid "submitting"
+msgstr "invio in corso..."

--- a/test/tymeslot_web/helpers/locale_completeness_test.exs
+++ b/test/tymeslot_web/helpers/locale_completeness_test.exs
@@ -72,6 +72,10 @@ defmodule TymeslotWeb.Helpers.LocaleCompletenessTest do
             assert result =~ ".", "German should use period as thousand separator"
             assert result =~ ",", "German should use comma as decimal separator"
 
+          "it" ->
+            assert result =~ ".", "Italian should use period as thousand separator"
+            assert result =~ ",", "Italian should use comma as decimal separator"
+
           "uk" ->
             assert result =~ " ", "Ukrainian should use space as thousand separator"
             assert result =~ ",", "Ukrainian should use comma as decimal separator"


### PR DESCRIPTION
   1. Configuration: Added Italian (it) to the list of supported locales in config/config.exs.
   2. Translations: Created the Italian translation files (.po) in priv/gettext/it/LC_MESSAGES/ for:
       * default.po: Main application strings (scheduling, navigation, etc.).
       * emails.po: All email templates and notifications.
       * errors.po: Error messages and status indicators.
   3. Locale Helpers: Updated lib/tymeslot_web/helpers/locale_format.ex to support Italian conventions for:
       * Date and time formats (e.g., 24h clock, day-month-year order).
       * Localized month and weekday names.
       * Number formatting (using . as thousands separator and , as decimal separator).
   4. Flag Support: Added the Italian flag mapping in lib/tymeslot_web/components/flag_helpers.ex so the language switcher displays the correct
      icon.
   5. Testing: Updated the locale completeness tests in test/tymeslot_web/helpers/locale_completeness_test.exs to include Italian.
