### PR TITLE
feat: private booking links (/b/:token)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,5 @@ data/
 uploads/
 
 # Coverage reports
+push.sh
+.dev/config/config

--- a/Dockerfile.docker
+++ b/Dockerfile.docker
@@ -1,5 +1,5 @@
 # Build stage
-FROM elixir:1.19.5 AS build
+FROM hexpm/elixir:1.19.5-erlang-28.3.3-debian-bookworm-20260223-slim AS build
 
 # Avoid prompts from apt and configure debconf
 ENV DEBIAN_FRONTEND=noninteractive
@@ -14,6 +14,7 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
     apt-get update && apt-get install -y \
     git \
     curl \
+    ca-certificates \
     build-essential \
     autoconf \
     m4 \
@@ -29,14 +30,23 @@ WORKDIR /app
 
 # Set build ENV early (before any mix commands)
 ENV MIX_ENV=prod \
+    ERL_FLAGS='+JMsingle true' \
     DEPLOYMENT_TYPE=docker
 
 # Copy mix files and config from tymeslot app (build context is apps/tymeslot/)
 COPY mix.exs mix.lock ./
 COPY config ./config
 
+# Install Hex and Rebar explicitly so the build does not depend on image defaults
+RUN mix local.hex --force && \
+    mix local.rebar --force
+
 # Get dependencies using committed lock file
 RUN mix deps.get --only prod
+
+# Compile dependencies before copying the full app source so local project files
+# do not interfere with Mix loading dependency projects.
+RUN mix deps.compile
 
 # Copy the rest of the application code. Wipe any locally-built assets first
 # so the image build is hermetic — assets are always produced by mix assets.deploy
@@ -44,13 +54,13 @@ RUN mix deps.get --only prod
 COPY . .
 RUN rm -rf priv/static/assets/
 
-# Compile dependencies and application code
-RUN mix do deps.compile + compile
+# Compile application code
+RUN mix compile
 
 # Install Tailwind and esbuild with retry mechanism
 RUN for i in 1 2 3 4 5; do \
         echo "Attempt $i: Installing tailwind and esbuild" && \
-        mix do tailwind.install + esbuild.install && break || sleep 5; \
+    mix do tailwind.install, esbuild.install && break || sleep 5; \
     done  
 
 # Install node_modules for tailwind plugins (tailwindcss-animate) — the
@@ -107,6 +117,7 @@ RUN chmod +x /app/start-docker.sh
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
     MIX_ENV=prod \
+    ERL_FLAGS='+JMsingle true' \
     DEPLOYMENT_TYPE=docker \
     PHX_SERVER=true \
     PORT=4000

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -25,8 +25,7 @@ config :tymeslot, TymeslotWeb.Endpoint,
   live_view: [signing_salt: "dev_liveview_signing_salt"],
   session_signing_salt: "dev_session_signing_salt",
   watchers: [
-    esbuild: {Esbuild, :install_and_run, [:tymeslot, ~w(--sourcemap=inline --watch)]},
-    tailwind: {Tailwind, :install_and_run, [:tymeslot, ~w(--watch)]},
+    esbuild: {Esbuild, :install_and_run, [:tymeslot, ~w(--sourcemap=inline --watch)]},    esbuild_bundles: {Esbuild, :install_and_run, [:bundles, ~w(--sourcemap=inline --watch)]},    tailwind: {Tailwind, :install_and_run, [:tymeslot, ~w(--watch)]},
     tailwind_quill: {Tailwind, :install_and_run, [:quill, ~w(--watch)]},
     tailwind_rhythm: {Tailwind, :install_and_run, [:rhythm, ~w(--watch)]}
   ],
@@ -53,9 +52,9 @@ config :phoenix_live_view,
 
 # Configure the database
 config :tymeslot, Tymeslot.Repo,
-  username: "postgres",
-  password: "postgres",
-  hostname: "localhost",
+  username: System.get_env("POSTGRES_USER", "postgres"),
+  password: System.get_env("POSTGRES_PASSWORD", "postgres"),
+  hostname: System.get_env("POSTGRES_HOST", "localhost"),
   database: "tymeslot_dev#{System.get_env("DB_SUFFIX")}",
   stacktrace: true,
   show_sensitive_data_on_connection_error: true,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -25,7 +25,9 @@ config :tymeslot, TymeslotWeb.Endpoint,
   live_view: [signing_salt: "dev_liveview_signing_salt"],
   session_signing_salt: "dev_session_signing_salt",
   watchers: [
-    esbuild: {Esbuild, :install_and_run, [:tymeslot, ~w(--sourcemap=inline --watch)]},    esbuild_bundles: {Esbuild, :install_and_run, [:bundles, ~w(--sourcemap=inline --watch)]},    tailwind: {Tailwind, :install_and_run, [:tymeslot, ~w(--watch)]},
+    esbuild: {Esbuild, :install_and_run, [:tymeslot, ~w(--sourcemap=inline --watch)]},
+    esbuild_bundles: {Esbuild, :install_and_run, [:bundles, ~w(--sourcemap=inline --watch)]},
+    tailwind: {Tailwind, :install_and_run, [:tymeslot, ~w(--watch)]},
     tailwind_quill: {Tailwind, :install_and_run, [:quill, ~w(--watch)]},
     tailwind_rhythm: {Tailwind, :install_and_run, [:rhythm, ~w(--watch)]}
   ],

--- a/lib/tymeslot/bookings/create.ex
+++ b/lib/tymeslot/bookings/create.ex
@@ -108,7 +108,8 @@ defmodule Tymeslot.Bookings.Create do
         organizer_user_id: Map.get(meeting_params, :organizer_user_id),
         meeting_type_id: Map.get(meeting_params, :meeting_type_id),
         video_integration_id: Map.get(meeting_params, :video_integration_id),
-        attendee_locale: Map.get(meeting_params, :attendee_locale) || default_locale()
+        attendee_locale: Map.get(meeting_params, :attendee_locale) || default_locale(),
+        private_booking: Map.get(meeting_params, :private_booking, false)
       }
 
       {:ok, booking_data}
@@ -156,7 +157,13 @@ defmodule Tymeslot.Bookings.Create do
     end
   end
 
+  # No meeting type attached — general meeting, no active check needed.
   defp validate_meeting_type_active(%{meeting_type_id: nil}, _user_id), do: :ok
+
+  # Private booking links authorise the booking regardless of is_active.
+  # The signed token is the booking authorisation; the organiser chose to share
+  # this link and cannot be blocked by the public is_active toggle.
+  defp validate_meeting_type_active(%{private_booking: true}, _user_id), do: :ok
 
   defp validate_meeting_type_active(%{meeting_type_id: type_id}, user_id) do
     alias Tymeslot.MeetingTypes

--- a/lib/tymeslot/meeting_types.ex
+++ b/lib/tymeslot/meeting_types.ex
@@ -110,6 +110,21 @@ defmodule Tymeslot.MeetingTypes do
   end
 
   @doc """
+  Generates a signed private booking URL token for the given meeting type.
+
+  Pass `valid_days` to limit the link's validity (e.g. 30 for 30 days).
+  Omit to create a permanent link.
+  """
+  @spec generate_private_link_token(Ecto.Schema.t(), pos_integer() | nil) :: String.t()
+  def generate_private_link_token(meeting_type, valid_days \\ nil) do
+    Tymeslot.MeetingTypes.PrivateLinkToken.sign(
+      meeting_type.user_id,
+      meeting_type.id,
+      valid_days
+    )
+  end
+
+  @doc """
   Finds a meeting type by its slug (derived from name).
   """
   @spec find_by_slug(integer(), String.t()) :: Ecto.Schema.t() | nil

--- a/lib/tymeslot/meeting_types.ex
+++ b/lib/tymeslot/meeting_types.ex
@@ -7,6 +7,7 @@ defmodule Tymeslot.MeetingTypes do
   alias Tymeslot.Integrations.Video
   alias Tymeslot.MeetingTypes.MeetingTypeQueries
   alias Tymeslot.MeetingTypes.MeetingTypeSchema
+  alias Tymeslot.MeetingTypes.PrivateLinkToken
   alias Tymeslot.Utils.ReminderUtils
   alias Tymeslot.Utils.UriUtils
   require Logger
@@ -117,7 +118,7 @@ defmodule Tymeslot.MeetingTypes do
   """
   @spec generate_private_link_token(Ecto.Schema.t(), pos_integer() | nil) :: String.t()
   def generate_private_link_token(meeting_type, valid_days \\ nil) do
-    Tymeslot.MeetingTypes.PrivateLinkToken.sign(
+    PrivateLinkToken.sign(
       meeting_type.user_id,
       meeting_type.id,
       valid_days

--- a/lib/tymeslot/meeting_types/meeting_type_queries.ex
+++ b/lib/tymeslot/meeting_types/meeting_type_queries.ex
@@ -8,12 +8,13 @@ defmodule Tymeslot.MeetingTypes.MeetingTypeQueries do
 
   @doc """
   Gets all active meeting types for a user, ordered by sort_order.
+  Excludes private meeting types (is_private: true) — those are only accessible via token links.
   """
   @spec list_active_meeting_types(integer()) :: [MeetingTypeSchema.t()]
   def list_active_meeting_types(user_id) do
     query =
       from(mt in MeetingTypeSchema,
-        where: mt.user_id == ^user_id and mt.is_active == true,
+        where: mt.user_id == ^user_id and mt.is_active == true and mt.is_private == false,
         order_by: [asc: mt.sort_order, asc: mt.name],
         preload: [:video_integration, :calendar_integration]
       )

--- a/lib/tymeslot/meeting_types/meeting_type_schema.ex
+++ b/lib/tymeslot/meeting_types/meeting_type_schema.ex
@@ -14,6 +14,7 @@ defmodule Tymeslot.MeetingTypes.MeetingTypeSchema do
           duration_minutes: integer() | nil,
           icon: String.t() | nil,
           is_active: boolean(),
+          is_private: boolean(),
           allow_video: boolean(),
           sort_order: integer(),
           reminder_config: [map()],
@@ -31,6 +32,7 @@ defmodule Tymeslot.MeetingTypes.MeetingTypeSchema do
     field(:duration_minutes, :integer)
     field(:icon, :string)
     field(:is_active, :boolean, default: true)
+    field(:is_private, :boolean, default: false)
     field(:allow_video, :boolean, default: false)
     field(:sort_order, :integer, default: 0)
     field(:target_calendar_id, :string)
@@ -71,6 +73,7 @@ defmodule Tymeslot.MeetingTypes.MeetingTypeSchema do
       :duration_minutes,
       :icon,
       :is_active,
+      :is_private,
       :allow_video,
       :sort_order,
       :user_id,

--- a/lib/tymeslot/meeting_types/private_link_token.ex
+++ b/lib/tymeslot/meeting_types/private_link_token.ex
@@ -1,0 +1,71 @@
+defmodule Tymeslot.MeetingTypes.PrivateLinkToken do
+  @moduledoc """
+  Signed tokens for private meeting-type booking links.
+
+  Encodes `{user_id, meeting_type_id, expires_at}` into a self-contained URL token.
+  No database storage is required — the token carries its own expiry.
+
+  ## Usage
+
+      # Generate a permanent link
+      token = PrivateLinkToken.sign(user_id, meeting_type_id)
+
+      # Generate a link valid for 30 days
+      token = PrivateLinkToken.sign(user_id, meeting_type_id, 30)
+
+      # Verify
+      {:ok, {user_id, meeting_type_id}} = PrivateLinkToken.verify(token)
+      {:error, :expired}               = PrivateLinkToken.verify(expired_token)
+  """
+
+  alias Phoenix.Token
+  alias Tymeslot.SignedToken
+
+  @salt "private_booking_link_v1"
+
+  @doc """
+  Signs a private booking token for the given user and meeting type.
+
+  Pass `valid_days` to create a time-limited link.
+  Omit (or pass `nil`) for a permanent link.
+  """
+  @spec sign(integer(), integer(), pos_integer() | nil) :: String.t()
+  def sign(user_id, meeting_type_id, valid_days \\ nil)
+      when is_integer(user_id) and is_integer(meeting_type_id) do
+    expires_at =
+      if is_integer(valid_days) and valid_days > 0,
+        do: System.os_time(:second) + valid_days * 86_400,
+        else: nil
+
+    Token.sign(TymeslotWeb.Endpoint, @salt, {user_id, meeting_type_id, expires_at})
+  end
+
+  @doc """
+  Verifies a private booking token.
+
+  Returns `{:ok, {user_id, meeting_type_id}}` on success.
+  Returns `{:error, :expired}` if the token's validity window has passed.
+  Returns `{:error, :invalid}` for malformed or tampered tokens.
+  """
+  @spec verify(String.t()) :: {:ok, {integer(), integer()}} | {:error, :expired | :invalid}
+  def verify(token) do
+    # We use :infinity for Phoenix.Token's own max_age — expiry is handled
+    # inside validate/1 using the embedded expires_at timestamp.
+    SignedToken.verify(token, @salt, :infinity, &validate/1)
+  end
+
+  # Permanent token (no expiry)
+  defp validate({user_id, mt_id, nil})
+       when is_integer(user_id) and is_integer(mt_id),
+       do: {:ok, {user_id, mt_id}}
+
+  # Time-limited token — check wall clock
+  defp validate({user_id, mt_id, expires_at})
+       when is_integer(user_id) and is_integer(mt_id) and is_integer(expires_at) do
+    if System.os_time(:second) <= expires_at,
+      do: {:ok, {user_id, mt_id}},
+      else: {:error, :expired}
+  end
+
+  defp validate(_), do: {:error, :invalid}
+end

--- a/lib/tymeslot/meeting_types/private_link_token.ex
+++ b/lib/tymeslot/meeting_types/private_link_token.ex
@@ -67,5 +67,5 @@ defmodule Tymeslot.MeetingTypes.PrivateLinkToken do
       else: {:error, :expired}
   end
 
-  defp validate(_), do: {:error, :invalid}
+  defp validate(_term), do: {:error, :invalid}
 end

--- a/lib/tymeslot/signed_token.ex
+++ b/lib/tymeslot/signed_token.ex
@@ -11,7 +11,9 @@ defmodule Tymeslot.SignedToken do
   Returns `{:ok, value}` if the token is valid and `validate.(value)` returns `{:ok, value}`,
   or `{:error, reason}` otherwise.
   """
-  @spec verify(String.t(), String.t(), pos_integer(), (term() -> {:ok, term()} | {:error, atom()})) ::
+  @spec verify(String.t(), String.t(), pos_integer() | :infinity, (term() ->
+                                                                     {:ok, term()}
+                                                                     | {:error, atom()})) ::
           {:ok, term()} | {:error, atom()}
   def verify(token, salt, max_age, validate) do
     case Token.verify(TymeslotWeb.Endpoint, salt, token, max_age: max_age) do

--- a/lib/tymeslot_web/live/dashboard/meeting_settings/card.ex
+++ b/lib/tymeslot_web/live/dashboard/meeting_settings/card.ex
@@ -4,6 +4,7 @@ defmodule TymeslotWeb.Dashboard.MeetingSettings.Card do
   """
   use Phoenix.Component
   alias Tymeslot.Integrations.Calendar
+  alias Tymeslot.MeetingTypes
   alias TymeslotWeb.Components.Icons.ProviderIcon
 
   @doc """
@@ -110,6 +111,24 @@ defmodule TymeslotWeb.Dashboard.MeetingSettings.Card do
 
         <%!-- Actions --%>
         <div class="flex items-center gap-1.5 flex-shrink-0">
+          <button
+            id={"copy-private-link-#{@type.id}"}
+            phx-hook="CopyOnClick"
+            data-copy-text={"#{TymeslotWeb.Endpoint.url()}/b/#{MeetingTypes.generate_private_link_token(@type)}"}
+            data-copy-feedback="Private link copied!"
+            class="p-1.5 text-tymeslot-500 hover:text-tymeslot-700 hover:bg-tymeslot-100 rounded-lg transition-colors"
+            title="Copy private booking link"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+              />
+            </svg>
+          </button>
+
           <button
             phx-click="edit_type"
             phx-value-id={@type.id}

--- a/lib/tymeslot_web/live/scheduling/handlers/booking_submission_handler_component.ex
+++ b/lib/tymeslot_web/live/scheduling/handlers/booking_submission_handler_component.ex
@@ -326,7 +326,8 @@ defmodule TymeslotWeb.Live.Scheduling.Handlers.BookingSubmissionHandlerComponent
         attendee_locale:
           socket.assigns[:locale] || Application.get_env(:tymeslot, :locales)[:default] || "en",
         # Always true for public booking flow
-        with_video_room: true
+        with_video_room: true,
+        private_booking: socket.assigns[:is_private_booking] || false
       }
     }
 

--- a/lib/tymeslot_web/live/scheduling/helpers.ex
+++ b/lib/tymeslot_web/live/scheduling/helpers.ex
@@ -19,7 +19,7 @@ defmodule TymeslotWeb.Live.Scheduling.Helpers do
 
   require Logger
 
-  import Component, only: [assign: 3]
+  import Component, only: [assign: 3, assign_new: 3]
 
   @doc """
   Handles username resolution and organizer setup.
@@ -29,7 +29,7 @@ defmodule TymeslotWeb.Live.Scheduling.Helpers do
   def handle_username_resolution(socket, nil) do
     socket
     |> store_client_ip()
-    |> assign(:username_context, nil)
+    |> assign_new(:username_context, fn -> nil end)
   end
 
   def handle_username_resolution(socket, username) do

--- a/lib/tymeslot_web/router.ex
+++ b/lib/tymeslot_web/router.ex
@@ -240,6 +240,23 @@ defmodule TymeslotWeb.Router do
     end
   end
 
+  # Private booking link routes (token-based, no username in URL)
+  scope "/", TymeslotWeb do
+    pipe_through :theme_browser
+
+    live_session :private_booking,
+      session: {__MODULE__, :scheduling_session, []},
+      on_mount: [
+        TymeslotWeb.Hooks.EmbedAuthHook,
+        TymeslotWeb.Hooks.LocaleHook,
+        TymeslotWeb.Hooks.ThemeHook,
+        TymeslotWeb.Hooks.ClientInfoHook
+      ] do
+      live "/b/:token", Themes.Core.Dispatcher, :private_schedule
+      live "/b/:token/book", Themes.Core.Dispatcher, :private_booking
+    end
+  end
+
   # Username-based scheduling routes (must be before catch-all)
   scope "/", TymeslotWeb do
     pipe_through :theme_browser

--- a/lib/tymeslot_web/themes/core/dispatcher.ex
+++ b/lib/tymeslot_web/themes/core/dispatcher.ex
@@ -10,7 +10,15 @@ defmodule TymeslotWeb.Themes.Core.Dispatcher do
 
   alias Tymeslot.Themes.{Registry, Theme}
   alias TymeslotWeb.Live.Scheduling.Helpers
-  alias TymeslotWeb.Themes.Core.{ErrorBoundary, EventBus, MeetingManagement, MountHelpers, PrivateBookingResolver}
+
+  alias TymeslotWeb.Themes.Core.{
+    ErrorBoundary,
+    EventBus,
+    MeetingManagement,
+    MountHelpers,
+    PrivateBookingResolver
+  }
+
   alias TymeslotWeb.Themes.Shared.{EventHandlers, LocaleHandler, PathHandlers}
 
   require Logger
@@ -33,7 +41,7 @@ defmodule TymeslotWeb.Themes.Core.Dispatcher do
            |> Phoenix.LiveView.put_flash(:error, "This booking link has expired.")
            |> Phoenix.LiveView.redirect(to: "/")}
 
-        {:error, _} ->
+        {:error, _reason} ->
           {:ok,
            socket
            |> Phoenix.LiveView.put_flash(:error, "Invalid booking link.")
@@ -46,7 +54,13 @@ defmodule TymeslotWeb.Themes.Core.Dispatcher do
 
         case socket.assigns do
           %{organizer_profile: %{} = profile} ->
-            MountHelpers.mount_with_profile(profile, params, session, socket, &delegate_to_theme/3)
+            MountHelpers.mount_with_profile(
+              profile,
+              params,
+              session,
+              socket,
+              &delegate_to_theme/3
+            )
 
           %{error: error} ->
             {:ok, assign(socket, :error, error)}

--- a/lib/tymeslot_web/themes/core/dispatcher.ex
+++ b/lib/tymeslot_web/themes/core/dispatcher.ex
@@ -8,6 +8,7 @@ defmodule TymeslotWeb.Themes.Core.Dispatcher do
   """
   use TymeslotWeb, :live_view
 
+  alias Tymeslot.MeetingTypes
   alias Tymeslot.Themes.{Registry, Theme}
   alias TymeslotWeb.Live.Scheduling.Helpers
 
@@ -38,14 +39,14 @@ defmodule TymeslotWeb.Themes.Core.Dispatcher do
         {:error, :expired} ->
           {:ok,
            socket
-           |> Phoenix.LiveView.put_flash(:error, "This booking link has expired.")
-           |> Phoenix.LiveView.redirect(to: "/")}
+           |> put_flash(:error, "This booking link has expired.")
+           |> redirect(to: "/")}
 
         {:error, _reason} ->
           {:ok,
            socket
-           |> Phoenix.LiveView.put_flash(:error, "Invalid booking link.")
-           |> Phoenix.LiveView.redirect(to: "/")}
+           |> put_flash(:error, "Invalid booking link.")
+           |> redirect(to: "/")}
       end
     else
       # For all routes with username (including meeting management), resolve the username first
@@ -96,7 +97,7 @@ defmodule TymeslotWeb.Themes.Core.Dispatcher do
       params =
         if action in [:private_schedule, :private_booking] do
           meeting_type = List.first(socket.assigns[:meeting_types] || [])
-          slug = meeting_type && Tymeslot.MeetingTypes.to_slug(meeting_type)
+          slug = meeting_type && MeetingTypes.to_slug(meeting_type)
           if slug, do: Map.put(params, "slug", slug), else: params
         else
           params

--- a/lib/tymeslot_web/themes/core/dispatcher.ex
+++ b/lib/tymeslot_web/themes/core/dispatcher.ex
@@ -10,7 +10,7 @@ defmodule TymeslotWeb.Themes.Core.Dispatcher do
 
   alias Tymeslot.Themes.{Registry, Theme}
   alias TymeslotWeb.Live.Scheduling.Helpers
-  alias TymeslotWeb.Themes.Core.{ErrorBoundary, EventBus, MeetingManagement, MountHelpers}
+  alias TymeslotWeb.Themes.Core.{ErrorBoundary, EventBus, MeetingManagement, MountHelpers, PrivateBookingResolver}
   alias TymeslotWeb.Themes.Shared.{EventHandlers, LocaleHandler, PathHandlers}
 
   require Logger
@@ -20,22 +20,43 @@ defmodule TymeslotWeb.Themes.Core.Dispatcher do
     # Initialize locale dropdown state
     socket = assign(socket, :language_dropdown_open, false)
 
-    # For all routes with username (including meeting management), resolve the username first
-    if params["username"] do
-      socket = Helpers.handle_username_resolution(socket, params["username"])
-
-      case socket.assigns do
-        %{organizer_profile: %{} = profile} ->
+    # Private booking links: token-based routes (/b/:token)
+    if socket.assigns.live_action in [:private_schedule, :private_booking] do
+      case PrivateBookingResolver.resolve(params["token"], socket) do
+        {:ok, socket} ->
+          profile = socket.assigns.organizer_profile
           MountHelpers.mount_with_profile(profile, params, session, socket, &delegate_to_theme/3)
 
-        %{error: error} ->
-          {:ok, assign(socket, :error, error)}
+        {:error, :expired} ->
+          {:ok,
+           socket
+           |> Phoenix.LiveView.put_flash(:error, "This booking link has expired.")
+           |> Phoenix.LiveView.redirect(to: "/")}
 
-        _no_profile ->
-          MountHelpers.mount_without_profile(params, session, socket, &delegate_to_theme/3)
+        {:error, _} ->
+          {:ok,
+           socket
+           |> Phoenix.LiveView.put_flash(:error, "Invalid booking link.")
+           |> Phoenix.LiveView.redirect(to: "/")}
       end
     else
-      MountHelpers.mount_without_profile(params, session, socket, &delegate_to_theme/3)
+      # For all routes with username (including meeting management), resolve the username first
+      if params["username"] do
+        socket = Helpers.handle_username_resolution(socket, params["username"])
+
+        case socket.assigns do
+          %{organizer_profile: %{} = profile} ->
+            MountHelpers.mount_with_profile(profile, params, session, socket, &delegate_to_theme/3)
+
+          %{error: error} ->
+            {:ok, assign(socket, :error, error)}
+
+          _no_profile ->
+            MountHelpers.mount_without_profile(params, session, socket, &delegate_to_theme/3)
+        end
+      else
+        MountHelpers.mount_without_profile(params, session, socket, &delegate_to_theme/3)
+      end
     end
   end
 
@@ -56,6 +77,17 @@ defmodule TymeslotWeb.Themes.Core.Dispatcher do
       # For meeting management, we don't need handle_params
       {:noreply, socket}
     else
+      # For private booking routes, inject the meeting type slug into params so the
+      # theme's handle_schedule_entry can resolve it via the normal slug lookup path.
+      params =
+        if action in [:private_schedule, :private_booking] do
+          meeting_type = List.first(socket.assigns[:meeting_types] || [])
+          slug = meeting_type && Tymeslot.MeetingTypes.to_slug(meeting_type)
+          if slug, do: Map.put(params, "slug", slug), else: params
+        else
+          params
+        end
+
       delegate_handle_params(params, url, socket)
     end
   end

--- a/lib/tymeslot_web/themes/core/private_booking_resolver.ex
+++ b/lib/tymeslot_web/themes/core/private_booking_resolver.ex
@@ -29,7 +29,7 @@ defmodule TymeslotWeb.Themes.Core.PrivateBookingResolver do
   def resolve(token, socket) do
     with {:ok, {user_id, meeting_type_id}} <- PrivateLinkToken.verify(token),
          {:ok, profile} <- ProfileQueries.get_by_user_id(user_id),
-         mt when not is_nil(mt) <- MeetingTypes.get_meeting_type(meeting_type_id, user_id) do
+         mt when is_map(mt) <- MeetingTypes.get_meeting_type(meeting_type_id, user_id) do
       socket =
         socket
         |> assign(:organizer_profile, profile)
@@ -44,7 +44,7 @@ defmodule TymeslotWeb.Themes.Core.PrivateBookingResolver do
       {:error, :expired} ->
         {:error, :expired}
 
-      {:error, _} ->
+      {:error, _reason} ->
         {:error, :invalid}
 
       nil ->

--- a/lib/tymeslot_web/themes/core/private_booking_resolver.ex
+++ b/lib/tymeslot_web/themes/core/private_booking_resolver.ex
@@ -1,0 +1,55 @@
+defmodule TymeslotWeb.Themes.Core.PrivateBookingResolver do
+  @moduledoc """
+  Resolves organizer context from a private booking token.
+
+  Used by the Dispatcher for `:private_schedule` and `:private_booking` actions,
+  where the meeting type and organizer are encoded in a signed URL token rather
+  than derived from a username/slug pair.
+  """
+
+  import Phoenix.Component, only: [assign: 3]
+
+  alias Tymeslot.MeetingTypes
+  alias Tymeslot.MeetingTypes.PrivateLinkToken
+  alias Tymeslot.Profiles.ProfileQueries
+
+  require Logger
+
+  @doc """
+  Decodes the token and assigns organizer context onto the socket.
+
+  On success returns `{:ok, socket}` with `:organizer_profile`, `:organizer_user_id`,
+  and `:meeting_types` assigned. The `:meeting_types` list contains only the single
+  meeting type encoded in the token, so the scheduling flow never shows other types.
+
+  On failure returns `{:error, reason}` where reason is `:expired` or `:invalid`.
+  """
+  @spec resolve(String.t(), Phoenix.LiveView.Socket.t()) ::
+          {:ok, Phoenix.LiveView.Socket.t()} | {:error, :expired | :invalid}
+  def resolve(token, socket) do
+    with {:ok, {user_id, meeting_type_id}} <- PrivateLinkToken.verify(token),
+         {:ok, profile} <- ProfileQueries.get_by_user_id(user_id),
+         mt when not is_nil(mt) <- MeetingTypes.get_meeting_type(meeting_type_id, user_id) do
+      socket =
+        socket
+        |> assign(:organizer_profile, profile)
+        |> assign(:organizer_user_id, user_id)
+        |> assign(:meeting_types, [mt])
+        |> assign(:username_context, profile.username)
+        |> assign(:page_title, "Schedule #{mt.name}")
+        |> assign(:is_private_booking, true)
+
+      {:ok, socket}
+    else
+      {:error, :expired} ->
+        {:error, :expired}
+
+      {:error, _} ->
+        {:error, :invalid}
+
+      nil ->
+        # meeting type not found / no longer active
+        {:error, :invalid}
+    end
+  end
+end

--- a/lib/tymeslot_web/themes/shared/live_helpers.ex
+++ b/lib/tymeslot_web/themes/shared/live_helpers.ex
@@ -207,8 +207,7 @@ defmodule TymeslotWeb.Themes.Shared.LiveHelpers do
            {:username_context, is_binary(socket.assigns[:username_context])},
          {:slug, slug} when is_binary(slug) <- {:slug, slug},
          {:meeting_type, nil} <-
-           {:meeting_type,
-            ThemeFlow.resolve_meeting_type_for_slug(socket.assigns[:organizer_user_id], slug)} do
+           {:meeting_type, resolve_meeting_type_by_slug(socket, slug)} do
       socket
       |> put_flash(:error, "Invalid meeting type")
       |> redirect(to: ~p"/#{socket.assigns[:username_context]}")
@@ -221,6 +220,14 @@ defmodule TymeslotWeb.Themes.Shared.LiveHelpers do
       _other ->
         do_handle_schedule_entry(socket, params)
     end
+  end
+
+  # Tries the public slug lookup first, then falls back to the pre-loaded meeting_types list.
+  # The fallback handles private meeting types (is_private: true) that are excluded from the
+  # public query but already verified by PrivateBookingResolver via token.
+  defp resolve_meeting_type_by_slug(socket, slug) do
+    ThemeFlow.resolve_meeting_type_for_slug(socket.assigns[:organizer_user_id], slug) ||
+      Enum.find(socket.assigns[:meeting_types] || [], &(MeetingTypes.to_slug(&1) == slug))
   end
 
   defp do_handle_schedule_entry(socket, params) do

--- a/lib/tymeslot_web/themes/shared/scheduling_init.ex
+++ b/lib/tymeslot_web/themes/shared/scheduling_init.ex
@@ -3,7 +3,7 @@ defmodule TymeslotWeb.Themes.Shared.SchedulingInit do
   Shared initialization helpers for scheduling themes.
   """
 
-  import Phoenix.Component, only: [assign: 3]
+  import Phoenix.Component, only: [assign: 3, assign_new: 3]
 
   alias Phoenix.LiveView
   alias TymeslotWeb.Live.Scheduling.Helpers
@@ -35,16 +35,16 @@ defmodule TymeslotWeb.Themes.Shared.SchedulingInit do
     |> Helpers.setup_form_state(%{}, as: :booking)
     |> assign(:client_ip, nil)
     |> assign(:submission_token, nil)
-    |> assign(:meeting_types, [])
+    |> assign_new(:meeting_types, fn -> [] end)
   end
 
   @spec assign_base_state(LiveView.Socket.t()) :: LiveView.Socket.t()
   def assign_base_state(socket) do
     socket
     |> assign(:current_state, :overview)
-    |> assign(:username_context, nil)
-    |> assign(:organizer_profile, nil)
-    |> assign(:organizer_user_id, nil)
+    |> assign_new(:username_context, fn -> nil end)
+    |> assign_new(:organizer_profile, fn -> nil end)
+    |> assign_new(:organizer_user_id, fn -> nil end)
     |> assign(:selected_duration, nil)
     |> assign(:selected_date, nil)
     |> assign(:selected_time, nil)

--- a/lib/tymeslot_web/themes/shared/state_machine_helpers.ex
+++ b/lib/tymeslot_web/themes/shared/state_machine_helpers.ex
@@ -40,7 +40,9 @@ defmodule TymeslotWeb.Themes.Shared.StateMachineHelpers do
     case live_action do
       :overview -> :overview
       :schedule -> :schedule
+      :private_schedule -> :schedule
       :booking -> :booking
+      :private_booking -> :booking
       :confirmation -> :confirmation
       _other -> :overview
     end

--- a/priv/repo/migrations/20260527081722_add_is_private_to_meeting_types.exs
+++ b/priv/repo/migrations/20260527081722_add_is_private_to_meeting_types.exs
@@ -1,0 +1,9 @@
+defmodule Tymeslot.Repo.Migrations.AddIsPrivateToMeetingTypes do
+  use Ecto.Migration
+
+  def change do
+    alter table(:meeting_types) do
+      add :is_private, :boolean, default: false, null: false
+    end
+  end
+end

--- a/test/tymeslot/meeting_types/private_link_token_test.exs
+++ b/test/tymeslot/meeting_types/private_link_token_test.exs
@@ -7,25 +7,24 @@ defmodule Tymeslot.MeetingTypes.PrivateLinkTokenTest do
   @moduletag :unit
   @moduletag :meeting_types
 
+  alias Phoenix.Token
   alias Tymeslot.MeetingTypes.PrivateLinkToken
 
   describe "sign/3 and verify/1" do
     test "round-trips a permanent token" do
       assert {:ok, {1, 42}} =
-               PrivateLinkToken.sign(1, 42)
-               |> PrivateLinkToken.verify()
+               PrivateLinkToken.verify(PrivateLinkToken.sign(1, 42))
     end
 
     test "round-trips a time-limited token that has not expired" do
       assert {:ok, {5, 99}} =
-               PrivateLinkToken.sign(5, 99, 30)
-               |> PrivateLinkToken.verify()
+               PrivateLinkToken.verify(PrivateLinkToken.sign(5, 99, 30))
     end
 
     test "returns :expired for a token with valid_days: 0 equivalent (already past)" do
       # Build a token whose expires_at is in the past by using negative seconds offset
       token =
-        Phoenix.Token.sign(
+        Token.sign(
           TymeslotWeb.Endpoint,
           "private_booking_link_v1",
           {7, 3, System.os_time(:second) - 1}
@@ -44,14 +43,14 @@ defmodule Tymeslot.MeetingTypes.PrivateLinkTokenTest do
 
     test "returns :invalid when payload has wrong shape" do
       bad_token =
-        Phoenix.Token.sign(TymeslotWeb.Endpoint, "private_booking_link_v1", "wrong_shape")
+        Token.sign(TymeslotWeb.Endpoint, "private_booking_link_v1", "wrong_shape")
 
       assert {:error, :invalid} = PrivateLinkToken.verify(bad_token)
     end
 
     test "returns :invalid when signed with a different salt" do
       bad_token =
-        Phoenix.Token.sign(TymeslotWeb.Endpoint, "wrong_salt", {1, 2, nil})
+        Token.sign(TymeslotWeb.Endpoint, "wrong_salt", {1, 2, nil})
 
       assert {:error, :invalid} = PrivateLinkToken.verify(bad_token)
     end

--- a/test/tymeslot/meeting_types/private_link_token_test.exs
+++ b/test/tymeslot/meeting_types/private_link_token_test.exs
@@ -8,6 +8,7 @@ defmodule Tymeslot.MeetingTypes.PrivateLinkTokenTest do
   @moduletag :meeting_types
 
   alias Phoenix.Token
+  alias Tymeslot.MeetingTypes
   alias Tymeslot.MeetingTypes.PrivateLinkToken
 
   describe "sign/3 and verify/1" do
@@ -87,13 +88,13 @@ defmodule Tymeslot.MeetingTypes.PrivateLinkTokenTest do
   describe "generate_private_link_token/2 (public MeetingTypes API)" do
     test "delegates to PrivateLinkToken.sign with user_id and id from struct" do
       mt = %{id: 7, user_id: 3}
-      token = Tymeslot.MeetingTypes.generate_private_link_token(mt)
+      token = MeetingTypes.generate_private_link_token(mt)
       assert {:ok, {3, 7}} = PrivateLinkToken.verify(token)
     end
 
     test "passes valid_days through" do
       mt = %{id: 7, user_id: 3}
-      token = Tymeslot.MeetingTypes.generate_private_link_token(mt, 14)
+      token = MeetingTypes.generate_private_link_token(mt, 14)
       assert {:ok, {3, 7}} = PrivateLinkToken.verify(token)
     end
   end

--- a/test/tymeslot/meeting_types/private_link_token_test.exs
+++ b/test/tymeslot/meeting_types/private_link_token_test.exs
@@ -1,0 +1,101 @@
+defmodule Tymeslot.MeetingTypes.PrivateLinkTokenTest do
+  @moduledoc """
+  Tests for private booking link token signing and verification.
+  """
+  use ExUnit.Case, async: true
+
+  @moduletag :unit
+  @moduletag :meeting_types
+
+  alias Tymeslot.MeetingTypes.PrivateLinkToken
+
+  describe "sign/3 and verify/1" do
+    test "round-trips a permanent token" do
+      assert {:ok, {1, 42}} =
+               PrivateLinkToken.sign(1, 42)
+               |> PrivateLinkToken.verify()
+    end
+
+    test "round-trips a time-limited token that has not expired" do
+      assert {:ok, {5, 99}} =
+               PrivateLinkToken.sign(5, 99, 30)
+               |> PrivateLinkToken.verify()
+    end
+
+    test "returns :expired for a token with valid_days: 0 equivalent (already past)" do
+      # Build a token whose expires_at is in the past by using negative seconds offset
+      token =
+        Phoenix.Token.sign(
+          TymeslotWeb.Endpoint,
+          "private_booking_link_v1",
+          {7, 3, System.os_time(:second) - 1}
+        )
+
+      assert {:error, :expired} = PrivateLinkToken.verify(token)
+    end
+
+    test "returns :invalid for a tampered token" do
+      assert {:error, :invalid} = PrivateLinkToken.verify("not.a.real.token")
+    end
+
+    test "returns :invalid for an empty string" do
+      assert {:error, :invalid} = PrivateLinkToken.verify("")
+    end
+
+    test "returns :invalid when payload has wrong shape" do
+      bad_token =
+        Phoenix.Token.sign(TymeslotWeb.Endpoint, "private_booking_link_v1", "wrong_shape")
+
+      assert {:error, :invalid} = PrivateLinkToken.verify(bad_token)
+    end
+
+    test "returns :invalid when signed with a different salt" do
+      bad_token =
+        Phoenix.Token.sign(TymeslotWeb.Endpoint, "wrong_salt", {1, 2, nil})
+
+      assert {:error, :invalid} = PrivateLinkToken.verify(bad_token)
+    end
+
+    test "permanent token contains only user_id and meeting_type_id in result" do
+      token = PrivateLinkToken.sign(10, 20)
+      assert {:ok, {10, 20}} = PrivateLinkToken.verify(token)
+    end
+
+    test "tokens for different meeting types are distinct" do
+      t1 = PrivateLinkToken.sign(1, 1)
+      t2 = PrivateLinkToken.sign(1, 2)
+
+      assert t1 != t2
+
+      assert {:ok, {1, 1}} = PrivateLinkToken.verify(t1)
+      assert {:ok, {1, 2}} = PrivateLinkToken.verify(t2)
+    end
+
+    test "tokens for different users are distinct" do
+      t1 = PrivateLinkToken.sign(1, 42)
+      t2 = PrivateLinkToken.sign(2, 42)
+
+      assert t1 != t2
+    end
+
+    test "time-limited token still valid one second before expiry" do
+      # expires in 1 day — definitely not expired
+      token = PrivateLinkToken.sign(1, 1, 1)
+      assert {:ok, {1, 1}} = PrivateLinkToken.verify(token)
+    end
+  end
+
+  describe "generate_private_link_token/2 (public MeetingTypes API)" do
+    test "delegates to PrivateLinkToken.sign with user_id and id from struct" do
+      mt = %{id: 7, user_id: 3}
+      token = Tymeslot.MeetingTypes.generate_private_link_token(mt)
+      assert {:ok, {3, 7}} = PrivateLinkToken.verify(token)
+    end
+
+    test "passes valid_days through" do
+      mt = %{id: 7, user_id: 3}
+      token = Tymeslot.MeetingTypes.generate_private_link_token(mt, 14)
+      assert {:ok, {3, 7}} = PrivateLinkToken.verify(token)
+    end
+  end
+end

--- a/test/tymeslot_web/live/private_booking_happy_path_test.exs
+++ b/test/tymeslot_web/live/private_booking_happy_path_test.exs
@@ -1,0 +1,229 @@
+defmodule TymeslotWeb.PrivateBookingHappyPathTest do
+  @moduledoc """
+  End-to-end test for private booking links (/b/:token).
+  """
+
+  use TymeslotWeb.LiveCase, async: false
+  @moduletag :utils
+
+  import Mox
+  import Tymeslot.Factory
+
+  alias Tymeslot.Infrastructure.AvailabilityCache
+  alias Tymeslot.MeetingTypes
+  alias Tymeslot.Meetings.MeetingSchema
+  alias Tymeslot.Repo
+  alias Tymeslot.TestMocks
+
+  setup :verify_on_exit!
+
+  setup tags do
+    Mox.set_mox_from_context(tags)
+    AvailabilityCache.clear_all()
+
+    TestMocks.setup_all_mocks()
+
+    :ok
+  end
+
+  @tag :capture_log
+  test "visitor can book a meeting via a private booking link", %{conn: conn} do
+    timezone = "America/New_York"
+    user = insert(:user)
+
+    profile =
+      insert(:profile,
+        user: user,
+        username: "privatehost",
+        booking_theme: "1",
+        timezone: timezone,
+        advance_booking_days: 30,
+        min_advance_hours: 0,
+        buffer_minutes: 0
+      )
+
+    _meeting_type =
+      insert(:meeting_type,
+        user: user,
+        duration_minutes: 30,
+        name: "Private Chat",
+        is_active: true,
+        is_private: true
+      )
+
+    Enum.each(1..7, fn day_of_week ->
+      insert(:weekly_availability,
+        profile: profile,
+        day_of_week: day_of_week,
+        is_available: true,
+        start_time: ~T[09:00:00],
+        end_time: ~T[17:00:00]
+      )
+    end)
+
+    _integration =
+      insert(:calendar_integration,
+        user: user,
+        is_active: true
+      )
+
+    # Get the private meeting type directly (list_active_meeting_types excludes private ones)
+    all_types = MeetingTypes.get_all_meeting_types(user.id)
+    mt = Enum.find(all_types, &(&1.is_private == true))
+
+    token = Tymeslot.MeetingTypes.generate_private_link_token(mt)
+
+    {:ok, view, _html} = live(conn, ~p"/b/#{token}?timezone=#{timezone}")
+
+    # The schedule step should be shown (not overview for private booking)
+    # Select a date
+    today = timezone |> DateTime.now!() |> DateTime.to_date()
+    target_date = Date.add(today, 1)
+    date_str = Date.to_string(target_date)
+
+    wait_until(fn ->
+      has_element?(view, "button.calendar-day[phx-value-date='#{date_str}']:not([disabled])")
+    end)
+
+    view
+    |> element("button.calendar-day[phx-value-date='#{date_str}']")
+    |> render_click()
+
+    wait_until(fn -> has_element?(view, "button.time-slot-button") end)
+
+    slot =
+      view
+      |> render()
+      |> Floki.parse_document!()
+      |> Floki.attribute("button.time-slot-button", "phx-value-time")
+      |> List.first() ||
+        flunk("Expected at least one available time slot button after selecting a date")
+
+    view
+    |> element("button.time-slot-button[phx-value-time='#{slot}']")
+    |> render_click()
+
+    view
+    |> element("button[phx-click='next_step']")
+    |> render_click()
+
+    attendee_email = "private-attendee@example.com"
+
+    view
+    |> form("form[phx-submit='submit']", %{
+      "booking" => %{
+        "name" => "Private Attendee",
+        "email" => attendee_email,
+        "message" => "Hello from private booking!"
+      }
+    })
+    |> render_submit()
+
+    wait_until(fn -> render(view) =~ "Meeting Confirmed!" end)
+
+    assert render(view) =~ attendee_email
+
+    meeting =
+      Repo.get_by!(MeetingSchema, organizer_user_id: user.id, attendee_email: attendee_email)
+
+    assert meeting.status == "confirmed"
+  end
+
+  @tag :capture_log
+  test "visitor can book via private link even when meeting type is inactive (is_active: false)", %{conn: conn} do
+    timezone = "America/New_York"
+    user = insert(:user)
+
+    profile =
+      insert(:profile,
+        user: user,
+        username: "privatehost2",
+        booking_theme: "1",
+        timezone: timezone,
+        advance_booking_days: 30,
+        min_advance_hours: 0,
+        buffer_minutes: 0
+      )
+
+    _meeting_type =
+      insert(:meeting_type,
+        user: user,
+        duration_minutes: 30,
+        name: "Inactive Private Chat",
+        is_active: false,
+        is_private: true
+      )
+
+    Enum.each(1..7, fn day_of_week ->
+      insert(:weekly_availability,
+        profile: profile,
+        day_of_week: day_of_week,
+        is_available: true,
+        start_time: ~T[09:00:00],
+        end_time: ~T[17:00:00]
+      )
+    end)
+
+    _integration =
+      insert(:calendar_integration,
+        user: user,
+        is_active: true
+      )
+
+    all_types = MeetingTypes.get_all_meeting_types(user.id)
+    mt = Enum.find(all_types, &(&1.is_private == true))
+    token = MeetingTypes.generate_private_link_token(mt)
+
+    {:ok, view, _html} = live(conn, ~p"/b/#{token}?timezone=#{timezone}")
+
+    today = timezone |> DateTime.now!() |> DateTime.to_date()
+    target_date = Date.add(today, 1)
+    date_str = Date.to_string(target_date)
+
+    wait_until(fn ->
+      has_element?(view, "button.calendar-day[phx-value-date='#{date_str}']:not([disabled])")
+    end)
+
+    view
+    |> element("button.calendar-day[phx-value-date='#{date_str}']")
+    |> render_click()
+
+    wait_until(fn -> has_element?(view, "button.time-slot-button") end)
+
+    slot =
+      view
+      |> render()
+      |> Floki.parse_document!()
+      |> Floki.attribute("button.time-slot-button", "phx-value-time")
+      |> List.first() ||
+        flunk("Expected at least one available time slot button after selecting a date")
+
+    view
+    |> element("button.time-slot-button[phx-value-time='#{slot}']")
+    |> render_click()
+
+    view
+    |> element("button[phx-click='next_step']")
+    |> render_click()
+
+    attendee_email = "inactive-private-attendee@example.com"
+
+    view
+    |> form("form[phx-submit='submit']", %{
+      "booking" => %{
+        "name" => "Private Attendee",
+        "email" => attendee_email,
+        "message" => "Hello from private booking!"
+      }
+    })
+    |> render_submit()
+
+    wait_until(fn -> render(view) =~ "Meeting Confirmed!" end)
+
+    meeting =
+      Repo.get_by!(MeetingSchema, organizer_user_id: user.id, attendee_email: attendee_email)
+
+    assert meeting.status == "confirmed"
+  end
+
+end

--- a/test/tymeslot_web/live/private_booking_happy_path_test.exs
+++ b/test/tymeslot_web/live/private_booking_happy_path_test.exs
@@ -71,7 +71,7 @@ defmodule TymeslotWeb.PrivateBookingHappyPathTest do
     all_types = MeetingTypes.get_all_meeting_types(user.id)
     mt = Enum.find(all_types, &(&1.is_private == true))
 
-    token = Tymeslot.MeetingTypes.generate_private_link_token(mt)
+    token = MeetingTypes.generate_private_link_token(mt)
 
     {:ok, view, _html} = live(conn, ~p"/b/#{token}?timezone=#{timezone}")
 

--- a/test/tymeslot_web/live/private_booking_happy_path_test.exs
+++ b/test/tymeslot_web/live/private_booking_happy_path_test.exs
@@ -10,8 +10,8 @@ defmodule TymeslotWeb.PrivateBookingHappyPathTest do
   import Tymeslot.Factory
 
   alias Tymeslot.Infrastructure.AvailabilityCache
-  alias Tymeslot.MeetingTypes
   alias Tymeslot.Meetings.MeetingSchema
+  alias Tymeslot.MeetingTypes
   alias Tymeslot.Repo
   alias Tymeslot.TestMocks
 
@@ -130,7 +130,8 @@ defmodule TymeslotWeb.PrivateBookingHappyPathTest do
   end
 
   @tag :capture_log
-  test "visitor can book via private link even when meeting type is inactive (is_active: false)", %{conn: conn} do
+  test "visitor can book via private link even when meeting type is inactive (is_active: false)",
+       %{conn: conn} do
     timezone = "America/New_York"
     user = insert(:user)
 
@@ -225,5 +226,4 @@ defmodule TymeslotWeb.PrivateBookingHappyPathTest do
 
     assert meeting.status == "confirmed"
   end
-
 end

--- a/test/tymeslot_web/live/scheduling/helpers_test.exs
+++ b/test/tymeslot_web/live/scheduling/helpers_test.exs
@@ -6,6 +6,10 @@ defmodule TymeslotWeb.Live.Scheduling.HelpersTest do
   alias Tymeslot.Availability.Calculate
   alias TymeslotWeb.Live.Scheduling.Helpers
 
+  defp mock_socket(assigns \\ %{}) do
+    %Phoenix.LiveView.Socket{assigns: Map.merge(%{__changed__: %{}}, assigns)}
+  end
+
   describe "get_week_days/4" do
     test "accepts user_timezone parameter and uses it for today detection" do
       week_start = ~D[2027-06-07]
@@ -53,6 +57,32 @@ defmodule TymeslotWeb.Live.Scheduling.HelpersTest do
       calendar_days = Calculate.get_calendar_days("Etc/UTC", 2027, 3, %{})
       assert Date.to_string(start_date) == List.first(calendar_days).date
       assert Date.to_string(end_date) == List.last(calendar_days).date
+    end
+  end
+
+  describe "handle_username_resolution/2 with nil username" do
+    test "preserves username_context already set on socket (private booking link)" do
+      socket = mock_socket(%{username_context: "alice"})
+
+      result = Helpers.handle_username_resolution(socket, nil)
+
+      assert result.assigns.username_context == "alice"
+    end
+
+    test "assigns nil when username_context is not present in assigns" do
+      socket = mock_socket()
+
+      result = Helpers.handle_username_resolution(socket, nil)
+
+      assert result.assigns.username_context == nil
+    end
+
+    test "keeps nil when username_context is already nil" do
+      socket = mock_socket(%{username_context: nil})
+
+      result = Helpers.handle_username_resolution(socket, nil)
+
+      assert result.assigns.username_context == nil
     end
   end
 end

--- a/test/tymeslot_web/themes/core/private_booking_resolver_test.exs
+++ b/test/tymeslot_web/themes/core/private_booking_resolver_test.exs
@@ -1,0 +1,122 @@
+defmodule TymeslotWeb.Themes.Core.PrivateBookingResolverTest do
+  @moduledoc """
+  Tests for the PrivateBookingResolver that decodes private booking tokens
+  and assigns organizer context onto the socket.
+  """
+  use Tymeslot.DataCase, async: true
+
+  @moduletag :database
+  @moduletag :meeting_types
+
+  import Phoenix.Component, only: [assign: 3]
+
+  alias Tymeslot.MeetingTypes.PrivateLinkToken
+  alias TymeslotWeb.Themes.Core.PrivateBookingResolver
+
+  # Minimal socket that satisfies Phoenix.Component.assign/3 validation.
+  # assign/3 accepts any %Phoenix.LiveView.Socket{} struct.
+  defp fake_socket do
+    %Phoenix.LiveView.Socket{}
+  end
+
+  describe "resolve/2 with a valid token" do
+    test "assigns organizer_profile, organizer_user_id, and meeting_types" do
+      user = insert(:user)
+      _profile = insert(:profile, user: user)
+      mt = insert(:meeting_type, user: user, is_active: true)
+
+      token = PrivateLinkToken.sign(user.id, mt.id)
+
+      assert {:ok, socket} = PrivateBookingResolver.resolve(token, fake_socket())
+      assert socket.assigns.organizer_user_id == user.id
+      assert [resolved_mt] = socket.assigns.meeting_types
+      assert resolved_mt.id == mt.id
+    end
+
+    test "meeting_types list contains exactly one entry" do
+      user = insert(:user)
+      _profile = insert(:profile, user: user)
+      _other_mt = insert(:meeting_type, user: user, name: "Other Call", is_active: true)
+      target_mt = insert(:meeting_type, user: user, name: "Target Call", is_active: true)
+
+      token = PrivateLinkToken.sign(user.id, target_mt.id)
+
+      assert {:ok, socket} = PrivateBookingResolver.resolve(token, fake_socket())
+      assert length(socket.assigns.meeting_types) == 1
+      assert hd(socket.assigns.meeting_types).id == target_mt.id
+    end
+
+    test "works for an inactive meeting type (private links bypass is_active)" do
+      user = insert(:user)
+      _profile = insert(:profile, user: user)
+      mt = insert(:meeting_type, user: user, is_active: false)
+
+      token = PrivateLinkToken.sign(user.id, mt.id)
+
+      assert {:ok, socket} = PrivateBookingResolver.resolve(token, fake_socket())
+      assert hd(socket.assigns.meeting_types).id == mt.id
+    end
+
+    test "assigns page_title containing the meeting type name" do
+      user = insert(:user)
+      _profile = insert(:profile, user: user)
+      mt = insert(:meeting_type, user: user, name: "Coffee Chat")
+
+      token = PrivateLinkToken.sign(user.id, mt.id)
+
+      assert {:ok, socket} = PrivateBookingResolver.resolve(token, fake_socket())
+      assert socket.assigns.page_title =~ "Coffee Chat"
+    end
+  end
+
+  describe "resolve/2 with an expired token" do
+    test "returns {:error, :expired}" do
+      user = insert(:user)
+      _profile = insert(:profile, user: user)
+      mt = insert(:meeting_type, user: user)
+
+      # Build a token that expired 1 second ago
+      expired_token =
+        Phoenix.Token.sign(
+          TymeslotWeb.Endpoint,
+          "private_booking_link_v1",
+          {user.id, mt.id, System.os_time(:second) - 1}
+        )
+
+      assert {:error, :expired} = PrivateBookingResolver.resolve(expired_token, fake_socket())
+    end
+  end
+
+  describe "resolve/2 with an invalid token" do
+    test "returns {:error, :invalid} for a garbage string" do
+      assert {:error, :invalid} = PrivateBookingResolver.resolve("garbage", fake_socket())
+    end
+
+    test "returns {:error, :invalid} when meeting type does not exist" do
+      user = insert(:user)
+      _profile = insert(:profile, user: user)
+
+      token = PrivateLinkToken.sign(user.id, 999_999)
+
+      assert {:error, :invalid} = PrivateBookingResolver.resolve(token, fake_socket())
+    end
+
+    test "returns {:error, :invalid} when user/profile does not exist" do
+      token = PrivateLinkToken.sign(999_999, 1)
+
+      assert {:error, :invalid} = PrivateBookingResolver.resolve(token, fake_socket())
+    end
+
+    test "returns {:error, :invalid} when meeting type belongs to a different user" do
+      user_a = insert(:user)
+      user_b = insert(:user)
+      _profile_b = insert(:profile, user: user_b)
+      mt_a = insert(:meeting_type, user: user_a)
+
+      # Token claims user_b owns mt_a — should be rejected
+      token = PrivateLinkToken.sign(user_b.id, mt_a.id)
+
+      assert {:error, :invalid} = PrivateBookingResolver.resolve(token, fake_socket())
+    end
+  end
+end

--- a/test/tymeslot_web/themes/core/private_booking_resolver_test.exs
+++ b/test/tymeslot_web/themes/core/private_booking_resolver_test.exs
@@ -10,6 +10,7 @@ defmodule TymeslotWeb.Themes.Core.PrivateBookingResolverTest do
 
   import Phoenix.Component, only: [assign: 3]
 
+  alias Phoenix.Token
   alias Tymeslot.MeetingTypes.PrivateLinkToken
   alias TymeslotWeb.Themes.Core.PrivateBookingResolver
 
@@ -77,7 +78,7 @@ defmodule TymeslotWeb.Themes.Core.PrivateBookingResolverTest do
 
       # Build a token that expired 1 second ago
       expired_token =
-        Phoenix.Token.sign(
+        Token.sign(
           TymeslotWeb.Endpoint,
           "private_booking_link_v1",
           {user.id, mt.id, System.os_time(:second) - 1}

--- a/test/tymeslot_web/themes/shared/live_helpers_test.exs
+++ b/test/tymeslot_web/themes/shared/live_helpers_test.exs
@@ -1,0 +1,97 @@
+defmodule TymeslotWeb.Themes.Shared.LiveHelpersTest do
+  use Tymeslot.DataCase, async: true
+
+  @moduletag :scheduling
+
+  alias Tymeslot.MeetingTypes
+  alias TymeslotWeb.Themes.Shared.LiveHelpers
+
+  # Minimal socket that satisfies handle_schedule_entry's pre-conditions:
+  # - username_context is a binary  (private-link guard check)
+  # - organizer_profile is nil      (prevents async availability fetch)
+  defp schedule_socket(extra_assigns \\ %{}) do
+    %Phoenix.LiveView.Socket{
+      assigns:
+        Map.merge(
+          %{
+            __changed__: %{},
+            flash: %{},
+            username_context: "testuser",
+            organizer_user_id: nil,
+            organizer_profile: nil,
+            meeting_types: [],
+            meeting_type: nil,
+            user_timezone: nil,
+            selected_duration: nil
+          },
+          extra_assigns
+        )
+    }
+  end
+
+  describe "handle_schedule_entry/2" do
+    test "assigns a private meeting type found in pre-loaded meeting_types list" do
+      # A private type is excluded from the public list_active_meeting_types query
+      # (which filters is_private == false), so the fallback to socket.assigns[:meeting_types]
+      # must find it.
+      user = insert(:user)
+
+      mt =
+        insert(:meeting_type,
+          user: user,
+          name: "Secret Session",
+          is_private: true,
+          is_active: true,
+          duration_minutes: 45
+        )
+
+      slug = MeetingTypes.to_slug(mt)
+
+      socket =
+        schedule_socket(%{
+          organizer_user_id: user.id,
+          meeting_types: [mt]
+        })
+
+      result = LiveHelpers.handle_schedule_entry(socket, %{"slug" => slug})
+
+      assert result.assigns.meeting_type.id == mt.id
+    end
+
+    test "assigns a public meeting type found via the normal slug lookup" do
+      user = insert(:user)
+
+      mt =
+        insert(:meeting_type,
+          user: user,
+          name: "Public Chat",
+          is_private: false,
+          is_active: true,
+          duration_minutes: 30
+        )
+
+      slug = MeetingTypes.to_slug(mt)
+
+      # meeting_types list is empty — must be found through the DB query
+      socket = schedule_socket(%{organizer_user_id: user.id, meeting_types: []})
+
+      result = LiveHelpers.handle_schedule_entry(socket, %{"slug" => slug})
+
+      assert result.assigns.meeting_type.id == mt.id
+    end
+
+    test "does not assign meeting_type when no match is found anywhere" do
+      user = insert(:user)
+      # Insert a meeting type so has_meeting_types? returns true and no defaults are created
+      _other = insert(:meeting_type, user: user, name: "Other", is_active: true)
+
+      socket = schedule_socket(%{organizer_user_id: user.id, meeting_types: []})
+
+      result = LiveHelpers.handle_schedule_entry(socket, %{"slug" => "no-such-type"})
+
+      # With an unmatched slug and a valid username_context, the socket is redirected.
+      # The meeting_type assign is NOT set (remains nil from mock).
+      assert result.redirected != nil
+    end
+  end
+end


### PR DESCRIPTION
## Description

Adds private booking links: a signed URL (`/b/:token`) that lets you share direct access to any meeting type's booking flow — bypassing the public schedule page and working even for inactive or unlisted meeting types.

The typical use case is sending a personal booking link to a specific person without exposing all your meeting types, or keeping a meeting type hidden from the public schedule while still sharing it selectively.

**Implementation:**

- **New routes** — `GET /b/:token` (date/time picker) and `GET /b/:token/book` (booking form) via `Themes.Core.Dispatcher`
- **`PrivateLinkToken`** — self-contained signed tokens encoding `{user_id, meeting_type_id, expires_at?}`; supports permanent and time-limited links
- **`PrivateBookingResolver`** — decodes the token on mount, scopes the scheduling UI to the single meeting type, sets `is_private_booking: true` on the socket
- **`MeetingTypes.generate_private_link_token/2`** — public context API
- **"Copy private link" button** on every meeting type card in dashboard settings
- **DB migration** — adds `is_private boolean NOT NULL DEFAULT false` to `meeting_types` for marking types as hidden from the public schedule
- **Booking validation** — `validate_meeting_type_active` skips the active-check when the booking arrives via a private link, so inactive meeting types remain bookable through their private URL

## Type of Change
- [x] New feature (private booking links)
- [x] Bug fix (private link booking was blocked for inactive meeting types)

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing completed

**New test files:** `private_link_token_test.exs`, `private_booking_happy_path_test.exs`, `private_booking_resolver_test.exs`, `helpers_test.exs`, `live_helpers_test.exs` — 50 tests covering active types, inactive types via private link, expired/tampered/invalid tokens, and the full booking flow end-to-end.

**Full suite:** 7917 tests, 13 failures — all pre-existing, none in files touched by this PR.

## Security Considerations

Tokens are signed with `Phoenix.Token` using a dedicated salt (`"private_booking_link_v1"`). Tampered tokens are rejected before any DB query. Time-limited links embed a signed `expires_at` timestamp so expiry cannot be bypassed by the client. Tokens expose only opaque integer IDs, no meeting type data.

## Breaking Changes

Requires running the migration (`20260527081722_add_is_private_to_meeting_types.exs`). No changes to existing booking or scheduling behaviour.