### PR TITLE
test(payments): enable payments in embed booking tests

### DIFF
--- a/test/tymeslot_web/live/scheduling/embed_paid_booking_test.exs
+++ b/test/tymeslot_web/live/scheduling/embed_paid_booking_test.exs
@@ -47,6 +47,7 @@ defmodule TymeslotWeb.Live.Scheduling.EmbedPaidBookingTest do
 
     setup_config(:tymeslot,
       feature_access_checker: Tymeslot.Features.DefaultAccessChecker,
+      meeting_payments_enabled: true,
       payment_application_fee_bp: 50
     )
 


### PR DESCRIPTION
## Summary

Enable the self-hosted `meeting_payments_enabled` feature flag in the paid
embedded-booking test setup.

Without this flag, the flow exits with `:payments_unavailable` before reaching
the configured Stripe adapter mock. The booking layer then surfaces this as
`:checkout_failed`, causing all four embed payment tests to fail.

## Verification

- paid embed booking tests: 4 passed
- full test suite: 10,987 passed, 0 failed, 104 excluded
- Credo strict: no issues
- focused format check: passed
- `git diff --check`: passed

## Unrelated baseline warning

Dialyzer still reports the existing unrelated warning:

`lib/tymeslot_web/components/dashboard_sidebar.ex:238:contract_with_opaque`
