### PR TITLE
fix(ci): align test DB pool with Oban concurrency

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -21,6 +21,7 @@ jobs:
           --health-timeout 5s --health-retries 5
     env:
       MIX_ENV: test
+      TEST_DB_POOL_SIZE: 10
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1


### PR DESCRIPTION
## Summary

Set `TEST_DB_POOL_SIZE` to 10 in the GitHub Actions verification workflow.

The default Oban queue concurrency is 10, while the test database pool
otherwise defaults to 8. Application startup validation therefore exits before
the test suite can run.

Fixes #69

## Verification

- application and test suite start successfully with the workflow configuration
- full suite: 10,996 of 11,000 passed, 104 excluded
- four known unrelated paid embed booking failures are addressed separately by PR #65
- Credo strict: no issues
- format check: passed
- `git diff --check`: passed

## Scope

This changes only the GitHub Actions test environment and does not modify
application or test code.
