### PR TITLE
fix(caldav): stop Nextcloud discovery silently querying the DAV service root

### DIFF
--- a/lib/tymeslot/integrations/calendar/caldav/url_builder.ex
+++ b/lib/tymeslot/integrations/calendar/caldav/url_builder.ex
@@ -100,11 +100,31 @@ defmodule Tymeslot.Integrations.Calendar.CalDAV.UrlBuilder do
   # (e.g., /dav/user@example.com or /remote.php/dav/calendars/user).
   defp full_caldav_url?(base_url) do
     case URI.parse(base_url).path do
-      nil -> false
-      "/" -> false
-      path -> length(String.split(path, "/", trim: true)) >= 2
+      nil ->
+        false
+
+      "/" ->
+        false
+
+      path ->
+        segments = String.split(path, "/", trim: true)
+        length(segments) >= 2 and not caldav_service_root?(segments)
     end
   end
+
+  # `Shared.PathUtils.normalize_url/2` turns a bare Nextcloud host into
+  # `.../remote.php/dav` before this module ever sees it (see
+  # `Nextcloud.Provider.new/1`). That path has depth 2, so it used to satisfy
+  # `full_caldav_url?/1` and get treated as an already-specific calendar
+  # collection — skipping the `/calendars/{username}/` this module would
+  # otherwise append. The resulting request queried the CalDAV *service
+  # root*, whose PROPFIND response lists top-level collections
+  # (files/, addressbooks/, calendars/, ...) that never carry a
+  # `<cal:calendar/>` resourcetype, so discovery silently returned zero
+  # calendars for every Nextcloud account — no error, no log, just an empty
+  # list indistinguishable from "this user really has no calendars".
+  defp caldav_service_root?(["remote.php", "dav"]), do: true
+  defp caldav_service_root?(_segments), do: false
 
   # Only include port when it differs from the scheme default.
   # URI.parse/1 always fills in the default port (443 for https, 80 for http),

--- a/test/tymeslot/integrations/calendar/caldav/url_builder_test.exs
+++ b/test/tymeslot/integrations/calendar/caldav/url_builder_test.exs
@@ -3,6 +3,63 @@ defmodule Tymeslot.Integrations.Calendar.CalDAV.UrlBuilderTest do
   @moduletag :integrations
 
   alias Tymeslot.Integrations.Calendar.CalDAV.UrlBuilder
+  alias Tymeslot.Integrations.Calendar.Nextcloud.Provider, as: NextcloudProvider
+
+  describe "build_discovery_url/1" do
+    # Regression: `Nextcloud.Provider.new/1` normalises a bare host through
+    # `Shared.PathUtils.normalize_url/2`, which turns
+    # "https://cloud.example.com" into "https://cloud.example.com/remote.php/dav"
+    # — a 2-segment path. `full_caldav_url?/1` treated any path of depth >= 2 as
+    # an already-specific calendar collection URL and skipped appending
+    # "/calendars/{username}/", so discovery queried the bare CalDAV *service
+    # root* instead of the user's calendar-home-set. That root's PROPFIND
+    # response lists top-level collections (files/, addressbooks/,
+    # calendars/, ...) that never carry a `<cal:calendar/>` resourcetype, so
+    # every Nextcloud discovery silently returned zero calendars — a real
+    # 2xx response, correctly parsed, just for the wrong resource — with no
+    # error surfaced anywhere. Confirmed live: the guessed path became
+    # `.../remote.php/dav/` instead of `.../remote.php/dav/calendars/alice/`.
+    test "appends /calendars/{username}/ for a bare Nextcloud host, even after Provider.new/1 normalisation" do
+      client =
+        NextcloudProvider.new(%{
+          base_url: "https://cloud.example.com",
+          username: "alice",
+          password: "x"
+        })
+
+      assert UrlBuilder.build_discovery_url(client) ==
+               "https://cloud.example.com/remote.php/dav/calendars/alice/"
+    end
+
+    test "does not double-append when base_url already includes /calendars/{username}" do
+      client = %{
+        base_url: "https://cloud.example.com/remote.php/dav/calendars/alice",
+        username: "alice",
+        provider: :nextcloud
+      }
+
+      assert UrlBuilder.build_discovery_url(client) ==
+               "https://cloud.example.com/remote.php/dav/calendars/alice/"
+    end
+
+    test "treats a user-pasted full calendar collection path as already specific" do
+      client = %{
+        base_url: "https://cloud.example.com/remote.php/dav/calendars/alice/personal",
+        username: "alice",
+        provider: :nextcloud
+      }
+
+      assert UrlBuilder.build_discovery_url(client) ==
+               "https://cloud.example.com/remote.php/dav/calendars/alice/personal/"
+    end
+
+    test "appends /{username}/ for a bare Radicale host" do
+      client = %{base_url: "https://radicale.example.com", username: "alice", provider: :radicale}
+
+      assert UrlBuilder.build_discovery_url(client) ==
+               "https://radicale.example.com/alice/"
+    end
+  end
 
   describe "build_calendar_url/2" do
     test "resolves a server-root-relative href against the base origin" do

--- a/test/tymeslot/integrations/calendar/discovery_test.exs
+++ b/test/tymeslot/integrations/calendar/discovery_test.exs
@@ -84,6 +84,55 @@ defmodule Tymeslot.Integrations.Calendar.DiscoveryTest do
       assert {:ok, calendars} = Discovery.discover_calendars_for_integration(integration)
       assert Enum.map(calendars, & &1.name) == ["Personal"]
     end
+
+    test "discovers for nextcloud provider even when base_url omits /remote.php/dav" do
+      # Regression: `Nextcloud.Provider.perform_connection_test/1` normalises
+      # `integration.base_url` through `PathUtils.normalize_url/2` before
+      # probing (see its moduledoc), but
+      # `Nextcloud.Provider.discover_calendars_for_integration/1` passed
+      # `integration.base_url` straight through unnormalised. A base_url
+      # persisted without `/remote.php/dav` (the format
+      # `Creation.prepare_attrs` actually stores) made "Test connection"
+      # succeed while the calendar picker silently found nothing, because the
+      # guessed discovery path became `<base_url>/calendars/<user>/` instead
+      # of the CalDAV-mounted `/remote.php/dav/calendars/<user>/`.
+      integration =
+        insert(:calendar_integration,
+          provider: "nextcloud",
+          base_url: "https://cloud.example.com",
+          username_encrypted: Encryption.encrypt("alice"),
+          password_encrypted: Encryption.encrypt("app-password")
+        )
+
+      stub(Tymeslot.HTTPClientMock, :request, fn :propfind, url, _body, _headers, _opts ->
+        assert url =~ "/remote.php/dav/", "probed wrong URL: #{url}"
+
+        {:ok,
+         %Req.Response{
+           status: 207,
+           body: """
+           <d:multistatus xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav">
+             <d:response>
+               <d:href>/remote.php/dav/calendars/alice/personal/</d:href>
+               <d:propstat>
+                 <d:prop>
+                   <d:displayname>Personal</d:displayname>
+                   <d:resourcetype>
+                     <d:collection/>
+                     <cal:calendar/>
+                   </d:resourcetype>
+                 </d:prop>
+                 <d:status>HTTP/1.1 200 OK</d:status>
+               </d:propstat>
+             </d:response>
+           </d:multistatus>
+           """
+         }}
+      end)
+
+      assert {:ok, calendars} = Discovery.discover_calendars_for_integration(integration)
+      assert Enum.map(calendars, & &1.name) == ["Personal"]
+    end
   end
 
   describe "discover_calendars_for_credentials/5" do


### PR DESCRIPTION
## Summary

`Nextcloud.Provider.new/1` normalises a bare host through `Shared.PathUtils.normalize_url/2`, turning `"https://cloud.example.com"` into `"https://cloud.example.com/remote.php/dav"` — a 2-segment path. `UrlBuilder.full_caldav_url?/1` treated any path of depth >= 2 as an already-specific calendar collection URL and skipped appending `/calendars/{username}/`, so discovery queried the bare CalDAV *service root* instead of the user's calendar-home-set.

That root's PROPFIND response lists top-level collections (`files/`, `addressbooks/`, `calendars/`, ...) that never carry a `<cal:calendar/>` resourcetype, so discovery returned a genuine 2xx response, correctly parsed, with zero calendars — for every Nextcloud account, silently, with no error anywhere in the stack. "Test connection" passes (it doesn't route through this URL-building path the same way), the connect-calendar wizard shows "No calendars were discovered," and there's nothing in the logs pointing at the actual cause.

## Root cause

Confirmed end-to-end against a live Nextcloud 34 instance: the generated discovery URL was `.../remote.php/dav/` instead of `.../remote.php/dav/calendars/<user>/`, even though the account had real calendars — a manual `curl` PROPFIND against the correct path returned them correctly, and the exact XML response fed straight into `XmlHandler.parse_calendar_discovery/1` parsed correctly too. I traced past every other candidate first (the two URL-normalisation call sites disagreeing, XML parsing against the real response body, circuit breaker/rate-limiter state, SSRF/DNS resolution, a WAF in front of the test server) before finding this one.

## Fix

`full_caldav_url?/1` now excludes the literal Nextcloud service-root path segments (`["remote.php", "dav"]`) from the "already specific" heuristic, so `UrlBuilder` still appends the per-user calendars path in that case, while continuing to respect a user-pasted full calendar path (e.g. `.../remote.php/dav/calendars/alice/personal`) as already complete.

`build_discovery_url/1` had no test coverage at all before this change — added a dedicated `describe` block covering the regression, the "don't double-append" case, the "user pasted a full path" case, and a sibling Radicale case as a sanity check that the general heuristic still works.

## Test plan

- [x] Full suite passes locally against current `main` (12,250 tests, 0 failures)
- [x] Deployed the fix in a personal instance and confirmed a real Nextcloud account's calendars now appear in the connect-calendar picker, where they previously silently showed "No calendars were discovered"