### PR TITLE
Open the schedule step on the next available day

### DIFF
--- a/lib/tymeslot_web/live/scheduling/availability_helpers.ex
+++ b/lib/tymeslot_web/live/scheduling/availability_helpers.ex
@@ -14,6 +14,7 @@ defmodule TymeslotWeb.Live.Scheduling.AvailabilityHelpers do
   alias Tymeslot.Meetings.BookingLimits.Checker
   alias Tymeslot.Profiles
   alias Tymeslot.Utils.ContextUtils
+  alias TymeslotWeb.Live.Scheduling.NextAvailable
 
   require Logger
 
@@ -308,6 +309,7 @@ defmodule TymeslotWeb.Live.Scheduling.AvailabilityHelpers do
         |> assign(:availability_status, :loaded)
         |> assign(:availability_task, nil)
         |> assign(:availability_task_ref, nil)
+        |> apply_auto_selection(context)
 
       {:error, reason} ->
         Logger.warning("Month availability fetch failed in sync mode", reason: inspect(reason))
@@ -317,6 +319,18 @@ defmodule TymeslotWeb.Live.Scheduling.AvailabilityHelpers do
         |> assign(:availability_status, :error)
         |> assign(:availability_task, nil)
         |> assign(:availability_task_ref, nil)
+    end
+  end
+
+  # The sync path resolves availability inside this call, so the auto-selection
+  # that production performs on the task result has to happen here too —
+  # otherwise it would be exercised by no test and ship unverified.
+  # A `:refetch` moves the window to the next month and recurses; the hop
+  # counter inside NextAvailable bounds the recursion.
+  defp apply_auto_selection(socket, context) do
+    case NextAvailable.apply(socket) do
+      {socket, :done} -> socket
+      {socket, :refetch} -> perform_sync_availability_fetch(socket, context)
     end
   end
 

--- a/lib/tymeslot_web/live/scheduling/next_available.ex
+++ b/lib/tymeslot_web/live/scheduling/next_available.ex
@@ -1,0 +1,217 @@
+defmodule TymeslotWeb.Live.Scheduling.NextAvailable do
+  @moduledoc """
+  Lands the booker on the first bookable day instead of an empty grid.
+
+  Entering the schedule step used to assign nothing but the current
+  month: `selected_date` stayed `nil`, so the booker faced a month of
+  greyed-out squares and had to hunt for a live one before a single time
+  appeared. Where the host was fully booked for the rest of the month
+  that hunt failed silently — the grid renders an all-disabled month
+  exactly the same way it renders a month nobody has looked at yet, and
+  nothing on screen suggests pressing "next month" would help.
+
+  So the selection is made from the availability map the schedule step
+  already fetches. `month_availability_map` is `%{"2026-01-15" => bool}`
+  over the 42-day display range, which is the same data the grid paints
+  from, so the day picked here is always a day the booker can see and
+  click. No extra query buys the common case.
+
+  Two boundaries decide the rest:
+
+    * The map spans a *display* range, not a calendar month, so it
+      carries days belonging to the neighbouring months. Selecting one
+      without moving the visible window would highlight a day drawn as
+      an adjacent-month square, or none at all — `align_to/2` moves the
+      month and the week to wherever the chosen day actually lives.
+
+    * When the whole range is dead the search steps forward a month at a
+      time, bounded by the resolved booking window. That bound is the same
+      one `CalendarNavigation.next_month_disabled?/4` uses to grey out the
+      forward arrow, so this never lands on a month the booker could not
+      have reached by hand.
+
+  A date carried in on the URL — a reschedule link, a shared link — is a
+  deliberate choice and is left untouched; `apply/1` only fills a blank
+  selection.
+  """
+
+  import Phoenix.Component, only: [assign: 3]
+
+  alias Tymeslot.Utils.DateTimeUtils
+
+  require Logger
+
+  # Guards the forward search against a pathological advance window. A host
+  # allowing bookings a year out whose calendar is empty would otherwise cost
+  # twelve availability fetches on a single page load.
+  @max_months_searched 3
+
+  @doc """
+  Selects the first available day and loads its slots.
+
+  Returns `{socket, :done}` when the work is finished — a day was
+  selected, the selection was left alone, or the search hit its bound —
+  and `{socket, :refetch}` when the window has been moved forward and the
+  caller must fetch availability for the new month.
+
+  The refetch is handed back rather than performed here because the two
+  fetch paths differ: tests resolve availability synchronously, production
+  spawns a task whose result arrives as a message. Returning the
+  instruction lets each caller re-enter its own path, and keeps this
+  module free of a dependency on the fetcher that calls it.
+  """
+  @spec apply(Phoenix.LiveView.Socket.t()) :: {Phoenix.LiveView.Socket.t(), :done | :refetch}
+  def apply(socket) do
+    if skip?(socket) do
+      {socket, :done}
+    else
+      case first_available_date(socket) do
+        nil -> search_forward(socket)
+        date -> {select(socket, date), :done}
+      end
+    end
+  end
+
+  # An explicit selection always wins over a computed one. A date named in the
+  # URL is seeded onto the socket by `do_handle_schedule_entry/2` before the
+  # fetch that triggers this runs, so a reschedule or shared link keeps the day
+  # it names rather than having it replaced by the earliest free one.
+  defp skip?(socket) do
+    socket.assigns[:selected_date] not in [nil, ""] or
+      socket.assigns[:is_rescheduling] == true or
+      socket.assigns[:current_state] != :schedule
+  end
+
+  @doc """
+  Returns the earliest bookable date string in the loaded availability
+  map, or `nil` when the map holds none.
+
+  Days before today are dropped even when the map marks them available:
+  the grid disables them unconditionally (`Calculate.determine_availability/6`
+  short-circuits on the past), and selecting one would load slots for a
+  day the booker cannot click.
+  """
+  @spec first_available_date(Phoenix.LiveView.Socket.t()) :: String.t() | nil
+  def first_available_date(socket) do
+    with map when is_map(map) <- socket.assigns[:month_availability_map],
+         today <- today_for(socket) do
+      map
+      |> Enum.filter(fn {date_string, available} ->
+        available == true and not past?(date_string, today)
+      end)
+      |> Enum.map(&elem(&1, 0))
+      |> Enum.min(fn -> nil end)
+    else
+      _not_loaded -> nil
+    end
+  end
+
+  # Date strings are ISO-8601, so lexicographic order is chronological
+  # order and the min/2 above needs no comparator.
+  defp past?(date_string, today) do
+    case Date.from_iso8601(date_string) do
+      {:ok, date} -> Date.compare(date, today) == :lt
+      _invalid -> true
+    end
+  end
+
+  # Moves the visible window onto the chosen day before selecting it, then
+  # asks for its slots. `handle_schedule_date_selection/2` in the theme core
+  # does the same three things on a click; this is that path without the
+  # click, so the two stay in step.
+  defp select(socket, date_string) do
+    socket
+    |> align_to(date_string)
+    |> assign(:selected_date, date_string)
+    |> assign(:selected_time, nil)
+    |> assign(:loading_slots, true)
+    |> assign(:calendar_error, nil)
+    |> tap(fn _socket -> send(self(), {:load_slots, date_string}) end)
+  end
+
+  # The month view keys off current_year/current_month; the week view
+  # (Rhythm) keys off current_week_start. Both move, so whichever theme is
+  # rendering shows the day that was just selected.
+  defp align_to(socket, date_string) do
+    case Date.from_iso8601(date_string) do
+      {:ok, date} ->
+        socket
+        |> assign(:current_year, date.year)
+        |> assign(:current_month, date.month)
+        |> assign(:current_week_start, Date.beginning_of_week(date, :monday))
+
+      _invalid ->
+        socket
+    end
+  end
+
+  # Nothing free in the loaded range: step the window forward and ask the
+  # caller to fetch again. `auto_select_months_searched` counts the hops so a
+  # host with a long, empty advance window cannot turn one page load into a
+  # chain of fetches.
+  defp search_forward(socket) do
+    months_searched = socket.assigns[:auto_select_months_searched] || 0
+    {year, month} = next_month(socket.assigns[:current_year], socket.assigns[:current_month])
+
+    cond do
+      months_searched >= @max_months_searched ->
+        Logger.debug("No availability found within searched window",
+          user_id: socket.assigns[:organizer_user_id],
+          months_searched: months_searched
+        )
+
+        {socket, :done}
+
+      beyond_booking_window?(socket, year, month) ->
+        {socket, :done}
+
+      true ->
+        socket =
+          socket
+          |> assign(:current_year, year)
+          |> assign(:current_month, month)
+          |> assign(
+            :current_week_start,
+            Date.beginning_of_week(Date.new!(year, month, 1), :monday)
+          )
+          |> assign(:month_availability_map, nil)
+          |> assign(:availability_status, :not_loaded)
+          |> assign(:auto_select_months_searched, months_searched + 1)
+
+        {socket, :refetch}
+    end
+  end
+
+  defp next_month(year, 12), do: {year + 1, 1}
+  defp next_month(year, month), do: {year, month + 1}
+
+  # Mirrors CalendarNavigation.next_month_disabled?/4 — the search must stop
+  # where the forward arrow does, or it would land the booker on a month the
+  # UI refuses to navigate to.
+  #
+  # Reads the `:booking_window_days` assign rather than resolving the window
+  # again. The window lives on the availability schedule a meeting type
+  # resolves to, not on the profile, and a meeting type may open a *longer*
+  # window than the organiser's default; resolving from the default here would
+  # stop the search short of days the forward arrow will happily reach. The
+  # assign is the same value the templates hand to `next_month_disabled?/4`,
+  # which is what makes this a mirror rather than a second opinion.
+  defp beyond_booking_window?(socket, year, month) do
+    case socket.assigns[:booking_window_days] do
+      days when is_integer(days) ->
+        max_booking_date = Date.add(today_for(socket), days)
+        Date.compare(Date.new!(year, month, 1), max_booking_date) != :lt
+
+      _absent ->
+        true
+    end
+  end
+
+  # The booker's own timezone decides which day is "today"; using UTC here
+  # would offer a day already past for anyone west of it.
+  defp today_for(socket) do
+    socket.assigns[:user_timezone]
+    |> DateTimeUtils.now_in_timezone()
+    |> DateTime.to_date()
+  end
+end

--- a/lib/tymeslot_web/themes/rhythm/scheduling/components/schedule_component.ex
+++ b/lib/tymeslot_web/themes/rhythm/scheduling/components/schedule_component.ex
@@ -21,15 +21,23 @@ defmodule TymeslotWeb.Themes.Rhythm.Scheduling.Components.ScheduleComponent do
   end
 
   @impl Phoenix.LiveComponent
+  # Selecting is not a toggle: clicking the day already selected re-selects it
+  # rather than clearing it, which is how Quill has always behaved.
+  #
+  # It used to clear it, and that was survivable only while the step opened
+  # with nothing selected — the booker could reach a selected day only by
+  # having just clicked it. The schedule step now opens on the first bookable
+  # day, so the highlighted day is the one most likely to be clicked first, and
+  # the toggle turned that click into an empty time list with the day
+  # unhighlighted. Nothing on screen distinguishes that from a day with no
+  # availability, and no affordance ever advertised deselection.
   def handle_event("select_date", %{"date" => date}, socket) do
-    new_date = if socket.assigns[:selected_date] == date, do: nil, else: date
-
     socket =
       socket
-      |> assign(:selected_date, new_date)
+      |> assign(:selected_date, date)
       |> assign(:selected_time, nil)
 
-    send(self(), {:step_event, :schedule, :select_date, new_date})
+    send(self(), {:step_event, :schedule, :select_date, date})
     {:noreply, socket}
   end
 

--- a/lib/tymeslot_web/themes/shared/info_handlers.ex
+++ b/lib/tymeslot_web/themes/shared/info_handlers.ex
@@ -10,6 +10,7 @@ defmodule TymeslotWeb.Themes.Shared.InfoHandlers do
 
   alias TymeslotWeb.Live.Scheduling.AvailabilityHelpers
   alias TymeslotWeb.Live.Scheduling.Handlers.SlotFetchingHandlerComponent
+  alias TymeslotWeb.Live.Scheduling.NextAvailable
 
   @doc """
   Handles calendar events updated via PubSub.
@@ -83,12 +84,34 @@ defmodule TymeslotWeb.Themes.Shared.InfoHandlers do
         |> assign(:availability_status, status)
         |> assign(:availability_task, nil)
         |> assign(:availability_task_ref, nil)
+        |> apply_auto_selection(status)
 
       {:noreply, socket}
     else
       {:noreply, socket}
     end
   end
+
+  # Landing the booker on the first bookable day. This runs on the task result
+  # rather than on schedule-step entry because the availability map does not
+  # exist yet at entry — it is precisely this message that carries it.
+  #
+  # A `:refetch` means the whole loaded range was dead, so the window has moved
+  # forward and needs its own fetch; the hop counter inside NextAvailable stops
+  # that walking forever.
+  #
+  # Only a loaded map is searched. On :error or :timeout the map is nil, which
+  # is indistinguishable from "no day is free" — advancing the month on a
+  # failed fetch would march the booker through months nobody has successfully
+  # looked at.
+  defp apply_auto_selection(socket, :loaded) do
+    case NextAvailable.apply(socket) do
+      {socket, :done} -> socket
+      {socket, :refetch} -> AvailabilityHelpers.fetch_month_availability_async(socket)
+    end
+  end
+
+  defp apply_auto_selection(socket, _failed), do: socket
 
   @doc """
   Handles common dropdown closing logic.

--- a/lib/tymeslot_web/themes/shared/live_helpers.ex
+++ b/lib/tymeslot_web/themes/shared/live_helpers.ex
@@ -309,6 +309,12 @@ defmodule TymeslotWeb.Themes.Shared.LiveHelpers do
       |> assign(:current_year, current_year)
       |> assign(:current_month, current_month)
       |> assign(:duration, normalized_duration)
+      # `mount` reaches this entry before `handle_params` runs, so a date named
+      # in the URL is not yet on the socket. Seeding it here is what lets the
+      # auto-selection below see an explicit choice and leave it alone —
+      # without this, entering with `?date=` fires a slot fetch for the
+      # auto-picked day whose late result overwrites the requested day's slots.
+      |> maybe_assign_from_params(:selected_date, params["date"])
 
     # Trigger month availability fetch in background if not already loading or loaded for this month
     if AvailabilityHelpers.can_fetch_availability?(socket) do

--- a/test/tymeslot_web/live/scheduling/next_available_test.exs
+++ b/test/tymeslot_web/live/scheduling/next_available_test.exs
@@ -1,0 +1,417 @@
+defmodule TymeslotWeb.Live.Scheduling.NextAvailableTest do
+  @moduledoc """
+  Pins the schedule step opening on a bookable day rather than an empty
+  grid.
+
+  The assertions are deliberately made against rendered output. Storing
+  `selected_date` is not the feature — painting a selected day and the
+  times that go with it is, and asserting only on the assign would pass
+  even if no component ever received the selection.
+
+  Three behaviours are covered, because each fails differently:
+
+    * the common case, where today's month has a free day;
+    * a month blacked out entirely, where the search has to move the
+      window forward and the booker must land on a *later* month;
+    * a date carried in on the URL, which is a deliberate choice and
+      must survive untouched.
+
+  The unit tests below cover the boundaries that are awkward to provoke
+  through the UI — a past date sitting in the map, and a fetch that
+  failed rather than returned an empty month.
+  """
+
+  use TymeslotWeb.LiveCase, async: false
+
+  @moduletag :scheduling
+  @moduletag :live
+
+  import Mox
+  import Tymeslot.Factory
+
+  alias Phoenix.LiveView.Socket
+  alias Tymeslot.Infrastructure.AvailabilityCache
+  alias Tymeslot.Profiles
+  alias Tymeslot.Security.RateLimiter
+  alias Tymeslot.TestMocks
+  alias TymeslotWeb.Live.Scheduling.NextAvailable
+
+  setup :verify_on_exit!
+
+  describe "landing on the first available day" do
+    setup tags do
+      Mox.set_mox_from_context(tags)
+      RateLimiter.clear_all()
+      AvailabilityCache.clear_all()
+      TestMocks.setup_all_mocks()
+
+      user = insert(:user)
+
+      profile =
+        insert(:profile,
+          user: user,
+          username: "nextavail",
+          booking_theme: "1",
+          timezone: "America/New_York"
+        )
+
+      # The booking window and the notice period live on the availability
+      # schedule, not the profile, and weekly availability hangs off that
+      # schedule — attaching it to the profile would leave the booker with no
+      # free day at all and the assertions below would pass over nothing.
+      schedule =
+        insert(:availability_schedule,
+          profile: profile,
+          is_default: true,
+          advance_booking_days: 90,
+          min_advance_hours: 0,
+          buffer_minutes: 0
+        )
+
+      insert(:meeting_type,
+        user: user,
+        duration_minutes: 30,
+        name: "Quick Chat",
+        is_active: true
+      )
+
+      Enum.each(1..7, fn day_of_week ->
+        insert(:weekly_availability,
+          schedule: schedule,
+          day_of_week: day_of_week,
+          is_available: true,
+          start_time: ~T[09:00:00],
+          end_time: ~T[17:00:00]
+        )
+      end)
+
+      insert(:calendar_integration, user: user, is_active: true)
+
+      %{profile: profile, user: user, schedule: schedule}
+    end
+
+    @tag :capture_log
+    test "the schedule step opens with a day selected and its times already listed",
+         %{conn: conn, profile: profile} do
+      {:ok, view, _html} = live(conn, "/#{profile.username}?timezone=#{profile.timezone}")
+
+      view |> element("button[data-testid='duration-option']") |> render_click()
+      view |> element("button[data-testid='next-step']") |> render_click()
+
+      # The slot list arrives on a follow-up message, exactly as it does
+      # after a manual day click.
+      wait_until(fn -> has_element?(view, "button.time-slot-button") end)
+
+      html = render(view)
+      document = Floki.parse_document!(html)
+
+      # A day is painted as selected. Without this the booker sees a grid
+      # with nothing chosen, which is the state this change removes.
+      selected = Floki.find(document, "button.calendar-day--selected")
+
+      assert selected != [],
+             "expected a calendar day to render as selected on entering the schedule step"
+
+      # ...and it is the day the flow actually holds, not a stale paint.
+      state = :sys.get_state(view.pid).socket.assigns
+      assert {:ok, %Date{}} = Date.from_iso8601(state.selected_date)
+      assert html =~ state.selected_date
+
+      # The times for that day are on screen, so the booker's next action
+      # is picking a time rather than hunting for a day.
+      slots = Floki.attribute(document, "button.time-slot-button", "phx-value-time")
+      assert slots != [], "expected the auto-selected day's slots to be rendered"
+
+      # No time is pre-picked — choosing the hour stays the booker's decision.
+      assert state.selected_time == nil
+      assert next_step_disabled?(view)
+    end
+
+    @tag :capture_log
+    test "a fully blacked-out month advances the window to a month that has availability",
+         %{conn: conn, profile: profile, schedule: schedule} do
+      timezone = profile.timezone
+      today = timezone |> DateTime.now!() |> DateTime.to_date()
+
+      # Black out every remaining day of the current month, plus the
+      # leading days of the next month that the 42-day display range
+      # reaches, so the first free day is genuinely in a later month.
+      blackout_end = today |> Date.end_of_month() |> Date.add(14)
+
+      Enum.each(Date.range(today, blackout_end), fn date ->
+        insert(:availability_override,
+          schedule: schedule,
+          date: date,
+          override_type: "unavailable"
+        )
+      end)
+
+      {:ok, view, _html} = live(conn, "/#{profile.username}?timezone=#{timezone}")
+
+      view |> element("button[data-testid='duration-option']") |> render_click()
+      view |> element("button[data-testid='next-step']") |> render_click()
+
+      wait_until(fn ->
+        :sys.get_state(view.pid).socket.assigns[:selected_date] != nil
+      end)
+
+      state = :sys.get_state(view.pid).socket.assigns
+      {:ok, landed_on} = Date.from_iso8601(state.selected_date)
+
+      # The booker is past the blackout, not parked on a dead month.
+      assert Date.compare(landed_on, blackout_end) == :gt,
+             "expected to land after the blackout, got #{state.selected_date}"
+
+      # The visible month moved with the selection — a selected day the
+      # grid is not showing would be invisible to the booker.
+      assert state.current_month == landed_on.month
+      assert state.current_year == landed_on.year
+
+      assert render(view) =~ state.selected_date
+    end
+
+    @tag :capture_log
+    test "a date supplied in the URL is kept instead of being overwritten",
+         %{conn: conn, profile: profile} do
+      timezone = profile.timezone
+      today = timezone |> DateTime.now!() |> DateTime.to_date()
+
+      # Far enough out to be a different day from any auto-selection.
+      chosen = Date.add(today, 21)
+      chosen_string = Date.to_string(chosen)
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          "/#{profile.username}/quick-chat?timezone=#{timezone}&date=#{chosen_string}"
+        )
+
+      wait_until(fn ->
+        :sys.get_state(view.pid).socket.assigns[:selected_date] != nil
+      end)
+
+      state = :sys.get_state(view.pid).socket.assigns
+
+      assert state.selected_date == chosen_string,
+             "a date named in the URL must survive the auto-selection"
+    end
+
+    @tag :capture_log
+    test "a URL date's slots are not overwritten by a fetch for the auto-picked day",
+         %{conn: conn, profile: profile, schedule: schedule} do
+      # `mount` enters the schedule step before `handle_params` applies the
+      # URL, so the auto-selection ran against an empty `selected_date`, chose
+      # today, and fired a slot fetch for it. That late result landed on top of
+      # the requested day's slots — the booker saw the right date highlighted
+      # above the wrong day's times. Asserting on `selected_date` alone misses
+      # this entirely, because the assign was always correct.
+      timezone = profile.timezone
+      today = timezone |> DateTime.now!() |> DateTime.to_date()
+
+      chosen = Date.add(today, 21)
+      chosen_string = Date.to_string(chosen)
+
+      # Slots render as bare times ("9:00 AM") carrying no date, so the only
+      # way to tell which day they were computed for is to make that day's
+      # hours unique. An afternoon-only window on the requested day cannot be
+      # confused with the 09:00 start every other day has.
+      insert(:availability_override,
+        schedule: schedule,
+        date: chosen,
+        override_type: "custom_hours",
+        start_time: ~T[14:00:00],
+        end_time: ~T[16:00:00]
+      )
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          "/#{profile.username}/quick-chat?timezone=#{timezone}&date=#{chosen_string}"
+        )
+
+      wait_until(fn -> has_element?(view, "button.time-slot-button") end)
+
+      state = :sys.get_state(view.pid).socket.assigns
+
+      assert state.selected_date == chosen_string
+      assert state.available_slots != []
+
+      # The requested day's window opens at 14:00 and closes at 16:00. A 9:00
+      # slot could only have come from a fetch for a different day.
+      assert "2:00 PM" in state.available_slots
+      refute "9:00 AM" in state.available_slots
+      refute "4:00 PM" in state.available_slots
+    end
+
+    # Rhythm's day button used to toggle: clicking the day already selected
+    # cleared the selection. That was harmless while the step opened with
+    # nothing selected, because the booker could only ever click an unselected
+    # day. Auto-selection makes the highlighted day the single most likely
+    # thing to be clicked, so the toggle turned the obvious first click into a
+    # blanked time list — the day unhighlighted, the slots gone, and no way to
+    # tell that from a day with no availability.
+    #
+    # Asserted through the rendered slot buttons rather than the assign: the
+    # assign going nil is the mechanism, but what makes it a bug is that the
+    # times vanish from the page.
+    @tag :capture_log
+    test "clicking the day the step opened on keeps it selected and keeps its times",
+         %{conn: conn, profile: profile} do
+      # "2" is Rhythm, whose day button carried the toggle.
+      {:ok, profile} = Profiles.update_profile(profile, %{booking_theme: "2"})
+
+      {:ok, view, _html} = live(conn, "/#{profile.username}?timezone=#{profile.timezone}")
+
+      view |> element("button[data-testid='duration-option']") |> render_click()
+      view |> element("button[data-testid='next-step']") |> render_click()
+
+      wait_until(fn -> has_element?(view, "button[data-testid='time-slot']") end)
+
+      selected =
+        view
+        |> render()
+        |> Floki.parse_document!()
+        |> Floki.find("button[data-testid='calendar-day'].selected")
+        |> Floki.attribute("phx-value-date")
+        |> List.first()
+
+      assert selected, "expected the schedule step to open with a day selected"
+
+      view
+      |> element("button[data-testid='calendar-day'][phx-value-date='#{selected}']")
+      |> render_click()
+
+      html = render(view)
+      document = Floki.parse_document!(html)
+
+      assert document
+             |> Floki.find("button[data-testid='calendar-day'].selected")
+             |> Floki.attribute("phx-value-date") == [selected],
+             "clicking the selected day deselected it"
+
+      assert Floki.find(document, "button[data-testid='time-slot']") != [],
+             "the times disappeared after clicking the selected day"
+    end
+  end
+
+  describe "first_available_date/1 boundaries" do
+    test "ignores days the map marks available but the grid draws as past" do
+      today = Date.utc_today()
+      yesterday = today |> Date.add(-1) |> Date.to_string()
+      tomorrow = today |> Date.add(1) |> Date.to_string()
+
+      # A stale map can carry a past day as available — the fetch covers a
+      # 42-day display range that begins before today. The grid disables
+      # those days unconditionally, so selecting one would load slots for a
+      # square the booker cannot click.
+      socket = socket_with(%{yesterday => true, tomorrow => true})
+
+      assert NextAvailable.first_available_date(socket) == tomorrow
+    end
+
+    test "returns the earliest available day, not merely the first in map order" do
+      today = Date.utc_today()
+      near = today |> Date.add(2) |> Date.to_string()
+      far = today |> Date.add(20) |> Date.to_string()
+
+      assert NextAvailable.first_available_date(socket_with(%{far => true, near => true})) == near
+    end
+
+    test "returns nil when every day in the map is taken" do
+      today = Date.utc_today()
+
+      map =
+        1..10
+        |> Enum.map(&{today |> Date.add(&1) |> Date.to_string(), false})
+        |> Map.new()
+
+      assert NextAvailable.first_available_date(socket_with(map)) == nil
+    end
+
+    test "returns nil when availability has not been loaded" do
+      assert NextAvailable.first_available_date(socket_with(nil)) == nil
+      assert NextAvailable.first_available_date(socket_with(:loading)) == nil
+    end
+  end
+
+  describe "apply/1" do
+    test "leaves an existing selection alone and asks for no refetch" do
+      socket = socket_with(%{}, selected_date: "2099-01-01")
+
+      assert {returned, :done} = NextAvailable.apply(socket)
+      assert returned.assigns.selected_date == "2099-01-01"
+    end
+
+    test "does not touch a reschedule in progress" do
+      socket = socket_with(%{}, is_rescheduling: true)
+
+      assert {returned, :done} = NextAvailable.apply(socket)
+      assert returned.assigns.selected_date == nil
+    end
+
+    test "stops searching once the hop budget is spent" do
+      # Standing in for a host whose calendar is empty for months: the
+      # search must give up rather than chain fetches across the whole
+      # advance-booking window on a single page load.
+      socket = socket_with(%{}, auto_select_months_searched: 3)
+
+      assert {_socket, :done} = NextAvailable.apply(socket)
+    end
+
+    test "asks for a refetch of the following month when the loaded range is dead" do
+      today = Date.utc_today()
+      socket = socket_with(%{(today |> Date.add(1) |> Date.to_string()) => false})
+
+      assert {moved, :refetch} = NextAvailable.apply(socket)
+
+      # The window advanced by exactly one month, and the map was cleared so
+      # the stale one cannot be mistaken for the new month's answer.
+      assert {moved.assigns.current_year, moved.assigns.current_month} !=
+               {socket.assigns.current_year, socket.assigns.current_month}
+
+      assert moved.assigns.month_availability_map == nil
+      assert moved.assigns.auto_select_months_searched == 1
+    end
+
+    test "does not advance past the host's advance-booking window" do
+      # A host taking bookings only a few days out has no next month to
+      # search; the forward arrow is disabled there and this must match it.
+      socket = socket_with(%{}, advance_booking_days: 3)
+
+      assert {_socket, :done} = NextAvailable.apply(socket)
+    end
+  end
+
+  defp next_step_disabled?(view) do
+    view
+    |> render()
+    |> Floki.parse_document!()
+    |> Floki.find("button[data-testid='next-step'][disabled]")
+    |> Enum.any?()
+  end
+
+  defp socket_with(availability_map, overrides \\ []) do
+    today = Date.utc_today()
+
+    assigns =
+      %{
+        __changed__: %{},
+        current_state: :schedule,
+        selected_date: Keyword.get(overrides, :selected_date, nil),
+        selected_time: nil,
+        is_rescheduling: Keyword.get(overrides, :is_rescheduling, false),
+        month_availability_map: availability_map,
+        current_year: today.year,
+        current_month: today.month,
+        current_week_start: Date.beginning_of_week(today, :monday),
+        user_timezone: "Etc/UTC",
+        booking_window_days: Keyword.get(overrides, :advance_booking_days, 90),
+        organizer_user_id: 1,
+        auto_select_months_searched: Keyword.get(overrides, :auto_select_months_searched, 0),
+        loading_slots: false,
+        calendar_error: nil
+      }
+
+    %Socket{assigns: assigns}
+  end
+end

--- a/test/tymeslot_web/live/scheduling/schedule_interaction_test.exs
+++ b/test/tymeslot_web/live/scheduling/schedule_interaction_test.exs
@@ -227,12 +227,13 @@ defmodule TymeslotWeb.Live.Scheduling.ScheduleInteractionTest do
              |> Floki.find("button.calendar-day[aria-current='date']")
              |> Enum.any?()
 
-      # A polite live region announces the slot-loading state — no date is
-      # selected yet, so it must announce the "pick a date" prompt, not just
-      # be present with the right attributes.
+      # A polite live region announces the slot-loading state. The schedule
+      # step now opens on the first bookable day, so the region carries slot
+      # state rather than the "pick a date" prompt — that prompt is only
+      # reachable once the booker clears the selection.
       assert html =~ ~s(role="status")
       assert html =~ ~s(aria-live="polite")
-      assert html =~ "Please select a date to see available times"
+      refute html =~ "Please select a date to see available times"
     end
 
     @tag :capture_log
@@ -261,7 +262,7 @@ defmodule TymeslotWeb.Live.Scheduling.ScheduleInteractionTest do
 
       assert html =~ ~s(role="status")
       assert html =~ ~s(aria-live="polite")
-      assert html =~ "Please select a date to see available times"
+      refute html =~ "Please select a date to see available times"
     end
   end
 


### PR DESCRIPTION
### Business use case

A booking page exists to convert a visitor into a booking. Every additional
action between arriving and choosing a time is a point where the visitor can
leave. The schedule step currently requires one action that produces no
information: finding a day that has availability at all.

The cost is highest for the hosts who are busiest, because their calendars have
the fewest open days to find.

### Motivation

After picking a duration, the visitor lands on a month grid with no day
selected and no times shown. To see any time, they must first click a day that
has availability. Which days those are is not stated; the visitor discovers it
by clicking.

When the host is fully booked for the remainder of the month, this fails
without feedback. A month where every day is disabled renders identically to a
month the visitor has not yet examined. Nothing indicates that moving forward
would help, so the visitor concludes there is no availability and leaves.

### What this changes

**From the visitor's perspective:** after picking a duration, the schedule step
opens with the earliest bookable day already selected and that day's times
already listed. The first thing they see is a list of times they can pick.
Choosing a different day still works exactly as before.

When the visible range has no availability, the calendar advances to the next
month that does, rather than showing an empty grid.

**What does not change:** a date supplied in the URL — a reschedule link or a
shared link — is kept. The visitor still chooses the time; only the day is
pre-selected.

### Design overview

`NextAvailable` reads the availability map the schedule step already fetches,
picks the earliest day the grid is painting as bookable, and loads that day's
slots. No extra query in the common case.

Three constraints shape it:

1. **The search is bounded by the same limit as the UI.** It stops where
   `CalendarNavigation.next_month_disabled?/4` greys out the forward arrow, so
   it cannot land on a month the visitor could not have reached manually.
2. **A hop counter caps the forward search**, so a host with a long empty
   advance window cannot turn one page load into a chain of fetches.
3. **Both fetch paths apply the selection.** Tests resolve availability
   synchronously; production spawns a task whose result arrives as a message.
   Hooking only one would leave the other unverified.

### Decision worth reviewing

When the current month is fully booked, the calendar **advances** to the next
month with availability. The alternative is to stay on the current month and
show a "Next available: 14 March" control. That is a small change in
`NextAvailable.search_forward/1` plus a template affordance. I chose advancing
because it removes an action; staying keeps the visitor oriented. Happy to
change it.

### Included fix

Rhythm's day button toggled: clicking the already-selected day cleared the
selection. This was unreachable in practice while the step opened with nothing
selected. With a day pre-selected it became the most likely first click, and it
produced an empty time list with no day highlighted — indistinguishable from a
day with no availability. The button now always selects, matching Quill.
