### PR TITLE
fix(scheduling): only carry theme= into locale redirects when previewing

### DIFF
--- a/lib/tymeslot_web/themes/shared/path_handlers.ex
+++ b/lib/tymeslot_web/themes/shared/path_handlers.ex
@@ -62,8 +62,20 @@ defmodule TymeslotWeb.Themes.Shared.PathHandlers do
 
   defp build_query_params(socket, locale) do
     %{"locale" => locale}
-    |> maybe_put_query_param("theme", socket.assigns[:theme_id])
+    |> maybe_put_query_param("theme", preview_theme_id(socket))
     |> maybe_put_query_param("reschedule_meeting_uid", socket.assigns[:reschedule_meeting_uid])
+  end
+
+  # `:theme_id` is the id of the theme currently being rendered and is always
+  # assigned (see `SchedulingInit.assign_theme_state/2`), so it is not by itself
+  # a signal that the visitor is previewing anything. Emitting it unconditionally
+  # meant that *any* visitor who switched language landed on a URL carrying
+  # `theme=`, which `ThemeUtils.assign_theme_with_preview/2` reads as a preview and
+  # `BookingSubmissionHandlerComponent.booking_orchestrator/1` then fails closed —
+  # silently making booking impossible. Only carry it when the page really is a
+  # theme preview, so switching language mid-preview still keeps the theme.
+  defp preview_theme_id(socket) do
+    if socket.assigns[:theme_preview], do: socket.assigns[:theme_id], else: nil
   end
 
   defp get_slug(socket) do

--- a/test/tymeslot_web/themes/shared/path_handlers_test.exs
+++ b/test/tymeslot_web/themes/shared/path_handlers_test.exs
@@ -15,7 +15,7 @@ defmodule TymeslotWeb.Themes.Shared.PathHandlersTest do
       }
 
       path = PathHandlers.build_path_with_locale(socket, "de")
-      assert path == "/johndoe?locale=de&theme=1"
+      assert path == "/johndoe?locale=de"
     end
 
     test "builds path for schedule action with duration" do
@@ -29,7 +29,7 @@ defmodule TymeslotWeb.Themes.Shared.PathHandlersTest do
       }
 
       path = PathHandlers.build_path_with_locale(socket, "uk")
-      assert path == "/johndoe/30-minutes?locale=uk&theme=2"
+      assert path == "/johndoe/30-minutes?locale=uk"
     end
 
     test "builds path for booking action" do
@@ -43,7 +43,7 @@ defmodule TymeslotWeb.Themes.Shared.PathHandlersTest do
       }
 
       path = PathHandlers.build_path_with_locale(socket, "en")
-      assert path == "/johndoe/60-minutes/book?locale=en&theme=1"
+      assert path == "/johndoe/60-minutes/book?locale=en"
     end
 
     test "builds path for confirmation action" do
@@ -56,7 +56,7 @@ defmodule TymeslotWeb.Themes.Shared.PathHandlersTest do
       }
 
       path = PathHandlers.build_path_with_locale(socket, "de")
-      assert path == "/johndoe/thank-you?locale=de&theme=2"
+      assert path == "/johndoe/thank-you?locale=de"
     end
 
     test "handles missing username context by falling back to root" do
@@ -69,7 +69,7 @@ defmodule TymeslotWeb.Themes.Shared.PathHandlersTest do
       }
 
       path = PathHandlers.build_path_with_locale(socket, "en")
-      assert path == "/?locale=en&theme=1"
+      assert path == "/?locale=en"
     end
 
     test "handles special characters in username" do
@@ -84,7 +84,7 @@ defmodule TymeslotWeb.Themes.Shared.PathHandlersTest do
       path = PathHandlers.build_path_with_locale(socket, "en")
       # Note: username in URL should be already encoded or handled by router,
       # but PathHandlers just joins them.
-      assert path == "/john.doe@example.com?locale=en&theme=1"
+      assert path == "/john.doe@example.com?locale=en"
     end
 
     test "omits theme and duration if not in assigns" do
@@ -112,7 +112,7 @@ defmodule TymeslotWeb.Themes.Shared.PathHandlersTest do
       }
 
       path = PathHandlers.build_path_with_locale(socket, "de")
-      assert path == "/johndoe?locale=de&reschedule_meeting_uid=abc-123&theme=1"
+      assert path == "/johndoe?locale=de&reschedule_meeting_uid=abc-123"
     end
 
     test "omits the reschedule uid when it is an empty string" do
@@ -126,7 +126,42 @@ defmodule TymeslotWeb.Themes.Shared.PathHandlersTest do
       }
 
       path = PathHandlers.build_path_with_locale(socket, "de")
-      assert path == "/johndoe?locale=de&theme=1"
+      assert path == "/johndoe?locale=de"
+    end
+
+    test "carries the theme while previewing so a locale switch keeps the preview" do
+      socket = %Phoenix.LiveView.Socket{
+        assigns: %{
+          username_context: "johndoe",
+          live_action: :overview,
+          theme_id: "2",
+          theme_preview: true
+        }
+      }
+
+      path = PathHandlers.build_path_with_locale(socket, "de")
+      assert path == "/johndoe?locale=de&theme=2"
+    end
+
+    test "does not carry the theme for an ordinary visitor" do
+      # Regression: `:theme_id` is always assigned, so emitting it unconditionally
+      # put every visitor who switched language onto a `theme=` URL. That reads as a
+      # preview downstream and fails the booking closed, silently making it
+      # impossible to book after changing the language.
+      socket = %Phoenix.LiveView.Socket{
+        assigns: %{
+          username_context: "johndoe",
+          live_action: :booking,
+          selected_duration: "30min",
+          theme_id: "1",
+          theme_preview: false
+        }
+      }
+
+      path = PathHandlers.build_path_with_locale(socket, "fr")
+
+      assert path == "/johndoe/30-minutes/book?locale=fr"
+      refute path =~ "theme="
     end
   end
 


### PR DESCRIPTION
Fixes #84.

## The problem

`build_query_params/2` carried `socket.assigns[:theme_id]` into every locale-switch
redirect. But `:theme_id` is the id of the theme currently being rendered and is
**always** assigned (`SchedulingInit.assign_theme_state/2`), so it is not by itself a
signal that anyone is previewing anything.

The consequence is that *any* visitor who changed the language landed on
`…/<slug>?locale=fr&theme=1`. Downstream, `ThemeUtils.assign_theme_with_preview/2` reads
the mere presence of a `theme` key as a preview:

```elixir
theme_switch  = Map.has_key?(params, "theme")
theme_preview = theme_switch or Map.has_key?(params, "preview")
```

and `BookingSubmissionHandlerComponent.booking_orchestrator/1` then fails closed:

```elixir
socket.assigns[:theme_preview] -> :preview_without_valid_token
```

So after switching language the visitor could pick a slot, fill the form and submit, and
nothing happened — no meeting row, no email, and no error in the server log. The flash
said *"Preview session expired"* although no preview session had ever existed.

## The change

Only carry `theme` when the page really is a theme preview:

```elixir
|> maybe_put_query_param("theme", preview_theme_id(socket))

defp preview_theme_id(socket) do
  if socket.assigns[:theme_preview], do: socket.assigns[:theme_id], else: nil
end
```

Switching language while previewing a theme still keeps the theme, which is what the
parameter is for. Ordinary visitors are no longer misclassified as previewers.

## Tests

`test/tymeslot_web/themes/shared/path_handlers_test.exs` asserted the old behaviour
(`assert path == "/johndoe?locale=de&theme=1"`) on sockets that had no `:theme_preview`,
so those expectations encoded the bug and are updated. Two tests are added:

- `carries the theme while previewing so a locale switch keeps the preview` — the
  legitimate case, with `theme_preview: true`, still emits `theme=`.
- `does not carry the theme for an ordinary visitor` — the regression guard, asserting
  the exact path and `refute path =~ "theme="`.

## Notes

The hardening suggested in #84 — requiring a `preview_token` to be present before
`theme_preview` is set at all — is deliberately **not** included here, to keep this
change small and reviewable. It would also cover the related problem noted in the issue,
where the two Theme-settings preview links build `?theme=<id>` without a `preview_token`
and so fail the owner's own preview closed. Happy to follow up with that separately if
you would like it.

## Checks

```
mix format --check-formatted   ok
mix credo --strict             113 checks, no issues
mix dialyzer                   done (passed successfully)
mix test path_handlers_test    17/17
mix test (full suite)          12386/12392
```

The six remaining failures are pre-existing on `main` and unrelated to this change — five
in `Tymeslot.Release.ChangelogConfigsTest` (failing in `setup`, inside `git!/2` while
building the throwaway repo) and one in `subscription_connect_test.exs:204`. I ran those
two files with and without this patch and got the identical result both times (10/15
passed, 5 failed), so they are environmental on my machine rather than caused here.
