### PR TITLE
fix(notifications): raise meeting.created for bookings with a video room

### DIFF
--- a/lib/tymeslot/workers/video_room/recovery.ex
+++ b/lib/tymeslot/workers/video_room/recovery.ex
@@ -28,9 +28,9 @@ defmodule Tymeslot.Workers.VideoRoom.Recovery do
   nor waits past its own deadline.
   """
 
-  alias Tymeslot.Meetings
   alias Tymeslot.Meetings.{MeetingQueries, MeetingSchema}
   alias Tymeslot.MeetingTypes.MeetingTypeQueries
+  alias Tymeslot.Notifications.Events
   alias Tymeslot.Utils.ReminderUtils
 
   require Logger
@@ -69,33 +69,34 @@ defmodule Tymeslot.Workers.VideoRoom.Recovery do
   @spec enter(String.t(), pos_integer(), String.t()) :: decision()
   def enter(meeting_id, attempt, cause) do
     if attempt == @fallback_attempt do
-      Logger.warning("Video room creation entering recovery, sending fallback emails",
+      Logger.warning("Video room creation entering recovery, announcing without a room",
         meeting_id: meeting_id,
         attempts: @fallback_attempt,
         cause: cause
       )
 
-      send_fallback_emails(meeting_id)
+      send_fallback_notifications(meeting_id)
     end
 
     decide(meeting_id, attempt - @fallback_attempt + 1)
   end
 
   @doc """
-  Sends the meeting's emails without a video room link.
+  Announces the meeting without a video room link.
 
   Used both on entering recovery and when the failure is already known to be
-  unrecoverable, so the attendees still receive their confirmation.
+  unrecoverable, so the attendees still receive their confirmation and anything
+  subscribed to `meeting.created` still learns about the booking.
   """
-  @spec send_fallback_emails(String.t()) :: :ok
-  def send_fallback_emails(meeting_id) do
-    Logger.info("Sending emails without video room due to creation failure",
+  @spec send_fallback_notifications(String.t()) :: :ok
+  def send_fallback_notifications(meeting_id) do
+    Logger.info("Announcing the meeting without a video room after creation failed",
       meeting_id: meeting_id
     )
 
     case MeetingQueries.get_meeting(meeting_id) do
       {:ok, meeting} ->
-        Meetings.schedule_email_notifications(meeting)
+        Events.meeting_created(meeting)
         :ok
 
       {:error, _reason} ->

--- a/lib/tymeslot/workers/video_room_worker.ex
+++ b/lib/tymeslot/workers/video_room_worker.ex
@@ -11,7 +11,12 @@ defmodule Tymeslot.Workers.VideoRoomWorker do
     for the job: wait it out, or stop trying.
   - `Tymeslot.Workers.VideoRoom.Recovery` takes over once ordinary retries are
     spent, pacing the remaining attempts against the moment the attendees
-    actually need the link and sending their emails without one meanwhile.
+    actually need the link and announcing the booking without one meanwhile.
+
+  When the caller asks for `send_emails`, it has deferred the whole
+  `meeting_created` event to this job rather than only its emails, so that every
+  notification carries the join link. This job is therefore what raises that
+  event for any booking with a video room.
 
   What is left here is the job itself: fetch the meeting, run the call under a
   timeout, and report the outcome.
@@ -26,6 +31,7 @@ defmodule Tymeslot.Workers.VideoRoomWorker do
   alias Ecto.Changeset
   alias Tymeslot.Meetings
   alias Tymeslot.Meetings.MeetingQueries
+  alias Tymeslot.Notifications.Events
   alias Tymeslot.Workers.VideoRoom.{ErrorPolicy, Recovery}
 
   require Logger
@@ -175,8 +181,8 @@ defmodule Tymeslot.Workers.VideoRoomWorker do
     )
 
     if send_emails and Map.get(meeting, :id) do
-      Logger.info("Scheduling emails with video room info", meeting_id: meeting.id)
-      Meetings.schedule_email_notifications(meeting)
+      Logger.info("Announcing the meeting now its room exists", meeting_id: meeting.id)
+      Events.meeting_created(meeting)
     end
 
     :ok
@@ -189,9 +195,9 @@ defmodule Tymeslot.Workers.VideoRoomWorker do
 
     cond do
       # No integration to call means no amount of retrying will produce a link,
-      # so give up now and let the attendees have their emails without one.
+      # so give up now and announce the booking without one.
       categorized in [:video_integration_missing, :video_integration_inactive] ->
-        if send_emails, do: Recovery.send_fallback_emails(meeting_id)
+        if send_emails, do: Recovery.send_fallback_notifications(meeting_id)
         {:discard, ErrorPolicy.discard_reason(categorized)}
 
       Recovery.recovering?(attempt, send_emails) ->

--- a/test/tymeslot/workers/video_room_worker_test.exs
+++ b/test/tymeslot/workers/video_room_worker_test.exs
@@ -11,10 +11,12 @@ defmodule Tymeslot.Workers.VideoRoomWorkerTest do
   alias Ecto.UUID
   alias Tymeslot.Meetings.MeetingQueries
   alias Tymeslot.Meetings.MeetingSchema
+  alias Tymeslot.Webhooks
   alias Tymeslot.Workers.CalendarEventWorker
   alias Tymeslot.Workers.EmailWorker
   alias Tymeslot.Workers.VideoRoom.Recovery
   alias Tymeslot.Workers.VideoRoomWorker
+  alias Tymeslot.Workers.WebhookWorker
   alias Tymeslot.ZoomOAuthHelperMock
 
   setup :verify_on_exit!
@@ -313,6 +315,82 @@ defmodule Tymeslot.Workers.VideoRoomWorkerTest do
 
       # Calendar update should be enqueued (if it fails, that's a separate concern)
       assert_enqueued(worker: CalendarEventWorker)
+    end
+  end
+
+  describe "perform/1 - the meeting.created fan-out" do
+    setup do
+      scenario = setup_video_scenario()
+
+      {:ok, webhook} =
+        Webhooks.create_webhook(scenario.user.id, %{
+          name: "Bookings",
+          url: "https://example.com/hooks/bookings",
+          events: ["meeting.created"]
+        })
+
+      Map.put(scenario, :webhook, webhook)
+    end
+
+    test "dispatches meeting.created once the room exists, not just the emails", %{
+      meeting: meeting
+    } do
+      expect_mirotalk_success()
+
+      assert :ok =
+               perform_job(VideoRoomWorker, %{
+                 "meeting_id" => meeting.id,
+                 "send_emails" => true
+               })
+
+      # The emails were never the whole event. Holding them until the room
+      # exists is the point of this job; holding the webhook and dropping it is
+      # not.
+      assert_enqueued(worker: EmailWorker)
+      assert_enqueued(worker: WebhookWorker)
+    end
+
+    test "dispatches meeting.created when the room can never be created", %{user: user} do
+      # A different slot from the scenario's own meeting: an organiser cannot
+      # hold two confirmed meetings at one time, and the database says so.
+      start_time = DateTime.utc_now() |> DateTime.add(3, :day) |> DateTime.truncate(:second)
+
+      meeting =
+        insert(:meeting,
+          organizer_user_id: user.id,
+          organizer_email: user.email,
+          video_integration_id: nil,
+          start_time: start_time,
+          end_time: DateTime.add(start_time, 30, :minute)
+        )
+
+      assert {:discard, "Video integration missing"} =
+               perform_job(
+                 VideoRoomWorker,
+                 %{"meeting_id" => meeting.id, "send_emails" => true},
+                 attempt: 1
+               )
+
+      # The attendees get their emails without a link; the subscriber has to
+      # learn about the booking all the same.
+      assert_enqueued(worker: EmailWorker)
+      assert_enqueued(worker: WebhookWorker)
+    end
+
+    test "stays silent when the notifications have already gone out", %{meeting: meeting} do
+      expect_mirotalk_success()
+
+      assert :ok =
+               perform_job(VideoRoomWorker, %{
+                 "meeting_id" => meeting.id,
+                 "send_emails" => false
+               })
+
+      # `send_emails: false` means the caller already announced the booking.
+      # Announcing it again would deliver the attendee a second confirmation and
+      # the subscriber a duplicate event.
+      refute_enqueued(worker: EmailWorker)
+      refute_enqueued(worker: WebhookWorker)
     end
   end
 


### PR DESCRIPTION
A booking whose meeting type provisions a video room raises no `meeting.created`
webhook. No Slack message either, and no Telegram one. The attendee and the
organiser do get their emails, so nothing looks wrong from the outside — the
subscriber simply never hears that the booking happened.

## Where it comes from

A booking with a video room defers its notifications to `VideoRoomWorker`, so
that every one of them carries the join link once the room exists. That is a
good design and this PR keeps it.

The job then does this:

```elixir
if send_emails and Map.get(meeting, :id) do
  Logger.info("Scheduling emails with video room info", meeting_id: meeting.id)
  Meetings.schedule_email_notifications(meeting)
end
```

`Meetings.schedule_email_notifications/1` is `Orchestrator.schedule_meeting_notifications/1`
— the emails, and only the emails. The webhook, Slack and Telegram dispatches
live in `Notifications.Events.meeting_created/1`, which the job never calls. So
of the event that was deferred, only the email half ever arrives.

## How far it reaches

All three creation paths hand off to that job in the same shape, so all three
lose the event whenever a room is involved:

| Path | Without a room | With a room |
|---|---|---|
| `Bookings.Create.handle_post_creation_effects/2` — the booking page | `Events.meeting_created` ✓ | job → emails only ✗ |
| `Bookings.CreateAdHoc.handle_side_effects/2` — the dashboard calendar | `Events.meeting_created` ✓ | job → emails only ✗ |
| `CheckoutSessionCompleted.enqueue_post_payment_effects/2` — a paid booking | `Events.meeting_created` ✓ | job → emails only ✗ |

A room is auto-created for MiroTalk, Google Meet, Teams and custom providers, so
this is the ordinary case for a video meeting type rather than an edge of one.

The recovery path has the same shape: when a room can never be created,
`Recovery` sends the emails without a link and the subscriber still hears
nothing at all.

## The fix

The job raises the whole event instead of its email half, on the success path
and on the fallback. Two call sites; none of the three creation paths are
touched.

Deferring the event rather than raising it at creation stays deliberate and
unchanged — it is what lets the payload carry the join link.

`send_emails: false` still announces nothing, and there is a test holding that
in place: the flag means the caller has already raised the event itself, and
raising it again would send the attendee a second confirmation and the
subscriber a duplicate.

`Recovery.send_fallback_emails/1` is now `send_fallback_notifications/1`, since
it no longer only sends emails.

`Meetings.schedule_email_notifications/1` is left where it is. It has no caller
left in Core beyond its own test, but it is public context API and I have no way
of seeing whether the cloud overlay leans on it.

## Tests

Three, in the worker's own suite: the event is raised once the room exists; it
is raised when the room can never be created; and it is not raised when the
caller has already raised it. The first two fail on `main` — the enqueued jobs
come back as two `EmailWorker` and one `CalendarEventWorker`, with no
`WebhookWorker` among them.
