### PR TITLE
feat(webhooks): include the meeting's guests in the payload

### DIFF
--- a/lib/tymeslot/meetings/meeting_queries.ex
+++ b/lib/tymeslot/meetings/meeting_queries.ex
@@ -40,6 +40,20 @@ defmodule Tymeslot.Meetings.MeetingQueries do
   end
 
   @doc """
+  Fetches a meeting with its guests loaded.
+
+  A webhook payload describes the meeting to an external system, and the people
+  invited to it are part of that description, so the delivery path needs them
+  alongside the meeting itself.
+  """
+  @spec get_meeting_with_guests(String.t()) :: {:ok, Meeting.t()} | {:error, :not_found}
+  def get_meeting_with_guests(id) do
+    with {:ok, meeting} <- get_meeting(id) do
+      {:ok, Repo.preload(meeting, :guests)}
+    end
+  end
+
+  @doc """
   Gets a single meeting by ID and locks it for update.
   """
   @spec get_meeting_for_update(String.t()) :: {:ok, Meeting.t()} | {:error, :not_found}

--- a/lib/tymeslot/webhooks/payload_builder.ex
+++ b/lib/tymeslot/webhooks/payload_builder.ex
@@ -68,6 +68,7 @@ defmodule Tymeslot.Webhooks.PayloadBuilder do
         location: meeting.location,
         organizer: build_organizer_data(meeting),
         attendee: build_attendee_data(meeting),
+        guests: build_guests_data(meeting),
         urls: build_urls(meeting),
         video: build_video_data(meeting),
         created_at: format_datetime(meeting.inserted_at),
@@ -96,6 +97,24 @@ defmodule Tymeslot.Webhooks.PayloadBuilder do
       message: meeting.attendee_message
     }
   end
+
+  # Guests are read from the loaded association rather than fetched here, so
+  # this module stays a pure function of the struct it is handed — which is how
+  # its tests build meetings, without a database. `WebhookWorker` loads them.
+  # A meeting arriving without the association yields an empty list rather than
+  # a crash, and the worker's own test covers the path that must not be empty.
+  defp build_guests_data(%MeetingSchema{guests: guests}) when is_list(guests) do
+    Enum.map(guests, fn guest ->
+      %{
+        email: guest.email,
+        name: guest.name,
+        status: guest.status,
+        responded_at: format_datetime(guest.responded_at)
+      }
+    end)
+  end
+
+  defp build_guests_data(_meeting), do: []
 
   defp build_urls(meeting) do
     %{

--- a/lib/tymeslot/workers/webhook_worker.ex
+++ b/lib/tymeslot/workers/webhook_worker.ex
@@ -47,7 +47,7 @@ defmodule Tymeslot.Workers.WebhookWorker do
     with {:ok, webhook} <- WebhookQueries.get_webhook(webhook_id),
          :ok = Logger.metadata(user_id: webhook.user_id),
          :ok <- check_feature_access(webhook.user_id, webhook_id, event_type, feature),
-         {:ok, meeting} <- MeetingQueries.get_meeting(meeting_id),
+         {:ok, meeting} <- MeetingQueries.get_meeting_with_guests(meeting_id),
          {:ok, _delivery} <- deliver_webhook(webhook, event_type, meeting, attempt) do
       :ok
     else

--- a/test/tymeslot/webhooks/payload_builder_test.exs
+++ b/test/tymeslot/webhooks/payload_builder_test.exs
@@ -6,6 +6,7 @@ defmodule Tymeslot.Webhooks.PayloadBuilderTest do
 
   import Tymeslot.Factory
 
+  alias Tymeslot.Meetings.GuestSchema
   alias Tymeslot.Webhooks.PayloadBuilder
 
   describe "build_payload/3" do
@@ -147,6 +148,49 @@ defmodule Tymeslot.Webhooks.PayloadBuilderTest do
       assert video.enabled == true
       assert is_nil(video.organizer_url)
       assert is_nil(video.attendee_url)
+    end
+  end
+
+  describe "build_payload/3 guests" do
+    test "describes each guest the meeting was booked with" do
+      meeting =
+        build(:meeting,
+          guests: [
+            %GuestSchema{
+              email: "colleague@example.com",
+              name: "A Colleague",
+              status: "accepted",
+              responded_at: ~U[2026-09-01 10:00:00Z]
+            }
+          ]
+        )
+
+      payload = PayloadBuilder.build_payload("meeting.created", meeting, "1")
+
+      assert [guest] = payload.data.meeting.guests
+      assert guest.email == "colleague@example.com"
+      assert guest.name == "A Colleague"
+      assert guest.status == "accepted"
+      assert guest.responded_at == "2026-09-01T10:00:00Z"
+    end
+
+    test "reports an empty list for a meeting booked without guests" do
+      meeting = build(:meeting, guests: [])
+
+      payload = PayloadBuilder.build_payload("meeting.created", meeting, "1")
+
+      assert payload.data.meeting.guests == []
+    end
+
+    test "reports an empty list rather than crashing on an unloaded association" do
+      # The builder formats what it is handed. A caller that forgets to load the
+      # association gets a payload that understates the meeting, which the
+      # worker's own test is there to catch — not a 500 on the delivery path.
+      meeting = build(:meeting)
+
+      payload = PayloadBuilder.build_payload("meeting.created", meeting, "1")
+
+      assert payload.data.meeting.guests == []
     end
   end
 

--- a/test/tymeslot/workers/webhook_worker_test.exs
+++ b/test/tymeslot/workers/webhook_worker_test.exs
@@ -10,6 +10,7 @@ defmodule Tymeslot.Workers.WebhookWorkerTest do
   import Tymeslot.WorkerTestHelpers
 
   alias Ecto.UUID
+  alias Tymeslot.Meetings.Guests
   alias Tymeslot.Webhooks.WebhookDeliverySchema
   alias Tymeslot.Webhooks.WebhookSchema
   alias Tymeslot.Workers.WebhookWorker
@@ -86,6 +87,28 @@ defmodule Tymeslot.Workers.WebhookWorkerTest do
       assert delivery.webhook_id == webhook.id
       assert delivery.response_status == 200
       assert delivery.delivered_at
+    end
+
+    test "carries the meeting's guests to the endpoint" do
+      meeting = insert(:meeting)
+      webhook = insert(:webhook)
+
+      {:ok, _guests} = Guests.create_for_meeting(meeting.id, ["colleague@example.com"])
+
+      expect(Tymeslot.HTTPClientMock, :post, fn _url, body, _headers, _opts ->
+        guests = body |> Jason.decode!() |> get_in(["data", "meeting", "guests"])
+
+        assert [%{"email" => "colleague@example.com", "status" => "pending"}] = guests
+
+        {:ok, %{status: 200, body: "ok"}}
+      end)
+
+      assert :ok =
+               perform_job(WebhookWorker, %{
+                 "webhook_id" => webhook.id,
+                 "event_type" => "meeting.created",
+                 "meeting_id" => meeting.id
+               })
     end
 
     test "records the failure when the remote endpoint responds with a 5xx error" do


### PR DESCRIPTION
A meeting booked with guests raises a `meeting.created` webhook that does not
mention them.

The guests themselves are handled properly — a row each, their own invitation
email, an RSVP token with accept and decline links. It is only the payload that
is silent, and the payload is all an integration has. A CRM receiving the event
mirrors the attendee and the organiser, and has no way to learn that two other
people were invited to the same meeting.

## What changes

`data.meeting` gains a `guests` array beside `attendee`:

```json
"guests": [
  {
    "email": "colleague@example.com",
    "name": null,
    "status": "pending",
    "responded_at": null
  }
]
```

`status` is the RSVP state the guest routes already maintain — `pending`,
`accepted`, `declined` — so a consumer can follow who actually confirmed rather
than only who was asked.

The change is additive. A consumer that ignores unknown keys sees no difference.

## Where the guests come from

`PayloadBuilder` is a pure function of the struct it is handed — its tests build
meetings with no database at all — so it formats the loaded association rather
than reaching for the repo itself. The delivery path uses a new
`MeetingQueries.get_meeting_with_guests/1` in place of `get_meeting/1`.

A meeting arriving without the association yields an empty list rather than a
crash. That is deliberate: the failure mode of a forgotten preload should be a
payload that understates the meeting — which the worker's own test is there to
catch — rather than a 500 on the delivery path, where the consequence would be a
retried, then eventually disabled, webhook.

If you would rather the builder fetched the guests itself and could never be
handed an incomplete meeting, say so and I will move it; it costs the
database-free payload tests, which is why I did not.

## Tests

Four, all failing on `main`:

- the payload describes each guest, with status and response time;
- it reports an empty list for a meeting booked without any;
- it reports an empty list rather than crashing on an unloaded association;
- the worker's real delivery path carries them to the endpoint.

On `main` the last one finds `guests` is `nil` in the delivered body.

## Verification

`mix precommit` passes: format, deps.unlock, compile ×2 with warnings as errors,
credo --strict, sobelow, deps.audit, excellent_migrations, actionlint, xref,
test, dialyzer. `mix gettext.extract --check-up-to-date` is clean too — this
change adds no translatable strings.

The same five `Tymeslot.Release.ChangelogConfigsTest` tests fail on my machine as
on my other branches: they shell out to `git` and `git-cliff` against a throwaway
repository in `tmp` and time out here. They load no application code, and they
are green on your CI.
