### PR TITLE
feat(config): set the default locale from DEFAULT_LOCALE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,15 @@ POSTGRES_PASSWORD=
 # want dashboard help links to point there instead.
 # DOCS_ARTICLE_BASE_URL=https://docs.yourdomain.com
 
+# OPTIONAL: Default language for visitors who express no preference (default: en)
+# Applies when there is no ?locale= parameter, no session locale and no
+# Accept-Language match — so it is what a visitor sees on a first, cold visit,
+# and what the server renders before the LiveView socket connects.
+# Must be one of the supported locales: en, de, fr, it, uk, cs
+# An unrecognised value stops the application at boot rather than silently
+# serving the wrong language.
+# DEFAULT_LOCALE=en
+
 # ====================
 # DATABASE SETTINGS
 # ====================

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -592,6 +592,25 @@ config :tymeslot,
 config :tymeslot, registration_enabled: System.get_env("REGISTRATION_ENABLED", "true") == "true"
 config :tymeslot, password_auth_enabled: System.get_env("PASSWORD_AUTH_ENABLED", "true") == "true"
 
+# Default locale for visitors who express no preference — no `?locale=`, no
+# session, no Accept-Language match. A self-hosted instance serving one country
+# wants this set once at deploy time rather than per visitor.
+#
+# This sets `:locales`'s `:default`, which `Tymeslot.Locales.default_locale/0`
+# reads, because that is the value the request pipeline actually resolves
+# against. `config :tymeslot, TymeslotWeb.Gettext, default_locale:` cannot serve
+# this purpose: Gettext reads a backend's `:default_locale` at compile time, so
+# overriding it from a release has no effect on rendering.
+#
+# `default_from_env/1` returns nil when unset or blank and raises on a code this
+# build cannot render. Keyword lists are deep merged, so `:supported` from
+# config/config.exs is preserved and only `:default` is replaced.
+default_locale = Tymeslot.Locales.default_from_env(System.get_env("DEFAULT_LOCALE"))
+
+if default_locale do
+  config :tymeslot, :locales, default: default_locale
+end
+
 # Social Authentication Configuration
 # These environment variables control whether social login is enabled
 #

--- a/lib/tymeslot/locales.ex
+++ b/lib/tymeslot/locales.ex
@@ -85,4 +85,41 @@ defmodule Tymeslot.Locales do
   def supported_codes do
     Enum.map(supported(), & &1.code)
   end
+
+  @doc """
+  Resolves a raw `DEFAULT_LOCALE` environment value into a locale code.
+
+  Returns `nil` when the value is absent or blank, so the caller leaves the
+  configured default untouched. Raises `ArgumentError` for a code that is not
+  supported: a deployment that asks for a language this build cannot render
+  should stop at boot rather than quietly serve a different one.
+
+  Called from `config/runtime.exs`; the pseudo locale is deliberately not
+  accepted here, since it is a dev-only rendering aid rather than a language a
+  deployment can choose to default to.
+  """
+  @spec default_from_env(term()) :: String.t() | nil
+  def default_from_env(value) when is_binary(value) do
+    case String.trim(value) do
+      "" ->
+        nil
+
+      code ->
+        codes = supported_codes()
+
+        if code in codes do
+          code
+        else
+          raise ArgumentError, """
+          Invalid DEFAULT_LOCALE: #{inspect(code)}
+
+          Supported locales: #{Enum.join(codes, ", ")}
+
+          Leave DEFAULT_LOCALE unset to keep the built-in default.
+          """
+        end
+    end
+  end
+
+  def default_from_env(_value), do: nil
 end

--- a/test/tymeslot/locales_test.exs
+++ b/test/tymeslot/locales_test.exs
@@ -152,4 +152,59 @@ defmodule Tymeslot.LocalesTest do
       refute Locales.pseudo_enabled?()
     end
   end
+
+  describe "default_from_env/1" do
+    setup do
+      Application.put_env(:tymeslot, :locales,
+        default: "en",
+        supported: [
+          %{code: "en", name: "English", country_code: :gbr},
+          %{code: "fr", name: "Français", country_code: :fra}
+        ]
+      )
+
+      :ok
+    end
+
+    test "returns a supported locale code unchanged" do
+      assert Locales.default_from_env("fr") == "fr"
+    end
+
+    test "trims surrounding whitespace" do
+      assert Locales.default_from_env("  fr\n") == "fr"
+    end
+
+    test "returns nil when unset so the configured default is left alone" do
+      assert Locales.default_from_env(nil) == nil
+    end
+
+    test "returns nil for a blank value" do
+      assert Locales.default_from_env("") == nil
+      assert Locales.default_from_env("   ") == nil
+    end
+
+    test "raises for a locale this build cannot render" do
+      assert_raise ArgumentError, ~r/Invalid DEFAULT_LOCALE: "de"/, fn ->
+        Locales.default_from_env("de")
+      end
+    end
+
+    test "the raised message lists the locales that are supported" do
+      assert_raise ArgumentError, ~r/Supported locales: en, fr/, fn ->
+        Locales.default_from_env("nope")
+      end
+    end
+
+    test "rejects the pseudo locale, which is a dev rendering aid not a language" do
+      Application.put_env(:tymeslot, :pseudo_locale_enabled, true)
+
+      assert_raise ArgumentError, fn ->
+        Locales.default_from_env(Locales.pseudo_locale())
+      end
+    end
+
+    test "returns nil for a non-binary value" do
+      assert Locales.default_from_env(:fr) == nil
+    end
+  end
 end


### PR DESCRIPTION
## The problem

A self-hosted instance serving one country cannot set the language its booking
pages open in. A visitor who expresses no preference — no `?locale=`, no session,
no `Accept-Language` match — always gets English, and the only way to change that
is to rebuild the image.

That visitor is not an edge case. It is the server-rendered first paint, before
the LiveView socket connects, and it is every request from a corporate proxy or a
mail-scanner that strips or delays JS. For a booking page whose audience is not
English-speaking, that is the first impression.

## Why the obvious knob doesn't work

`config :tymeslot, TymeslotWeb.Gettext, default_locale: "fr"` looks like the
setting, but Gettext reads a backend's `:default_locale` at **compile time**.
Setting it in a release moves `Application.get_env/2` and changes nothing that
renders. I confirmed this on a live 1.11.1 instance:

```
Application.get_env(:tymeslot, TymeslotWeb.Gettext)  #=> [default_locale: "fr"]
Application.get_env(:gettext, :default_locale)       #=> "fr"
Gettext.get_locale(TymeslotWeb.Gettext)              #=> "en"   ← unchanged
```

The value the request pipeline actually resolves against is `:locales`'s
`:default`, read at runtime by `Tymeslot.Locales.default_locale/0`. Setting *that*
to `"fr"` switched the booking page immediately:

```
curl -H 'Accept-Language;'          → <html lang="fr">  "Choisissez"
curl -H 'Accept-Language: en-US'    → <html lang="en">  "Book a"
```

An explicit preference still wins, which is the behaviour you'd want.

## The change

`DEFAULT_LOCALE` is resolved by `Tymeslot.Locales.default_from_env/1` and written
to `:locales`'s `:default` in `config/runtime.exs`. The resolution lives in the
module rather than inline in runtime.exs, following `Infrastructure.ProxyConfig`
and `Mailer.Providers`, so it is covered by tests.

+120 lines across four files, no deletions, no behaviour change when unset.

An unrecognised code raises at boot rather than silently serving the wrong
language — following the reasoning already written down for `EMAIL_ADAPTER`
("an unrecognised value raises rather than silently discarding every email").
The pseudo locale is rejected too: it is a dev rendering aid, not a language a
deployment can default to.

Keyword lists are deep merged, so `:supported` from `config/config.exs` is
untouched and only `:default` is replaced.

## Why an env var

Every other deployment knob is one — `PHX_HOST`, `EMAIL_FROM_ADDRESS`,
`SMTP_HOST`, `REGISTRATION_ENABLED`, `URL_SCHEME`. Language is the exception, and
it is among the first things a non-English self-hoster reaches for. I got there
by hand-editing `sys.config` inside a running container, which does not survive
the next image rebuild.

## Open questions for you

1. **Should `config :tymeslot, TymeslotWeb.Gettext, default_locale:` follow it?**
   I left it alone deliberately — it is inert for rendering, and I did not want to
   imply otherwise. But leaving the two disagreeing (`"en"` there, `"fr"` in
   `:locales`) is its own kind of confusing. Happy to align them, or to add a
   comment in `config.exs` saying the Gettext key is compile-time only.
2. **Timezone is the same shape of problem** (`Europe/Tallinn` in `profiles.ex`
   and the `core.js` fallback), but I have deliberately not touched it here —
   you mentioned in #62 that detection should fall back to the organiser's
   timezone, and I would rather not collide with that. Happy to open a separate
   issue if a `DEFAULT_TIMEZONE` would be welcome once that lands.

## Testing

`test/tymeslot/locales_test.exs` gains a `default_from_env/1` block covering: a
supported code, whitespace trimming, nil and blank returning nil so the
configured default is left alone, an unsupported code raising, the raised
message listing what *is* supported, the pseudo locale being rejected, and a
non-binary value. The module already carries `@moduletag :utils`.

Run against the toolchain this repo pins (`.tool-versions`: erlang 28.5.0.5,
elixir 1.20.3-otp-28), in `hexpm/elixir:1.20.3-erlang-28.5.0.5-debian-bookworm`
with a throwaway `postgres:16`:

```
mix format --check-formatted        PASS
mix compile --warnings-as-errors    PASS
mix credo --strict                  PASS
mix ecto.create && mix ecto.migrate ok
mix test test/tymeslot/locales_test.exs
  25 tests, 0 failures   (17 before this change, 8 added)
```

The rendering behaviour was separately verified on a self-hosted 1.11.1
instance by setting `:locales`'s `:default` directly.
