### PR TITLE
fix: paginate Google incremental calendar sync

### DIFF
--- a/lib/tymeslot/integrations/calendar/google/google_calendar_api.ex
+++ b/lib/tymeslot/integrations/calendar/google/google_calendar_api.ex
@@ -249,31 +249,40 @@ defmodule Tymeslot.Integrations.Calendar.Google.CalendarAPI do
     sync_token = integration.google_sync_token
 
     AccessToken.with_access_token(integration, &__MODULE__.refresh_token/1, fn token ->
-      result =
-        CalendarCircuitBreaker.call(:google, fn ->
-          make_request(:get, "/calendars/#{URI.encode(calendar_id)}/events", token, %{
-            "syncToken" => sync_token
-          })
-        end)
-
-      case result do
-        {:ok, response} when is_map(response) ->
-          {:ok,
-           %{
-             events: response["items"] || [],
-             next_sync_token: response["nextSyncToken"]
-           }}
-
-        {:ok, error} ->
-          error
-
-        {:error, :circuit_open} = error ->
-          error
-
-        other ->
-          other
-      end
+      fetch_incremental_page(token, calendar_id, sync_token, nil, [])
     end)
+  end
+
+  defp fetch_incremental_page(token, calendar_id, sync_token, page_token, acc) do
+    params = maybe_put_page_token(%{"syncToken" => sync_token}, page_token)
+
+    result =
+      CalendarCircuitBreaker.call(:google, fn ->
+        make_request(:get, "/calendars/#{URI.encode(calendar_id)}/events", token, params)
+      end)
+
+    case result do
+      {:ok, response} when is_map(response) ->
+        items = response["items"] || []
+        acc = Enum.reverse(items, acc)
+
+        case response["nextPageToken"] do
+          nil ->
+            {:ok, %{events: Enum.reverse(acc), next_sync_token: response["nextSyncToken"]}}
+
+          next_page ->
+            fetch_incremental_page(token, calendar_id, sync_token, next_page, acc)
+        end
+
+      {:ok, error} ->
+        error
+
+      {:error, :circuit_open} = error ->
+        error
+
+      other ->
+        other
+    end
   end
 
   @doc """

--- a/test/tymeslot/integrations/calendar/google/calendar_api_test.exs
+++ b/test/tymeslot/integrations/calendar/google/calendar_api_test.exs
@@ -449,6 +449,61 @@ defmodule Tymeslot.Integrations.Calendar.Google.CalendarAPITest do
     end
   end
 
+  describe "list_events_incremental/1" do
+    setup do
+      breaker_pid = Process.whereis(:calendar_breaker_google)
+      Mox.allow(Tymeslot.HTTPClientMock, self(), breaker_pid)
+      user = insert(:user)
+
+      integration =
+        insert(:calendar_integration,
+          user: user,
+          provider: "google",
+          access_token_encrypted: Encryption.encrypt("valid_token"),
+          token_expires_at: DateTime.add(DateTime.utc_now(), 3600),
+          google_sync_token: "sync_old"
+        )
+
+      %{integration: integration}
+    end
+
+    defp sync_response(items, extra),
+      do:
+        {:ok,
+         %Req.Response{status: 200, body: Jason.encode!(Map.merge(%{"items" => items}, extra))}}
+
+    test "single-page response returns events and the sync token", %{integration: integration} do
+      expect(Tymeslot.HTTPClientMock, :request, fn :get, url, _body, _headers, _opts ->
+        assert String.contains?(url, "syncToken=sync_old")
+        refute String.contains?(url, "pageToken=")
+        sync_response([%{"id" => "evt1"}], %{"nextSyncToken" => "sync_new"})
+      end)
+
+      assert {:ok, %{events: [%{"id" => "evt1"}], next_sync_token: "sync_new"}} =
+               CalendarAPI.list_events_incremental(integration)
+    end
+
+    # Regression: a multi-page delta was truncated after page 1, and since
+    # Google only returns nextSyncToken on the final page, the stored token
+    # was never advanced — every later run re-fetched the same stale page.
+    test "multi-page response accumulates all events and returns the final sync token",
+         %{integration: integration} do
+      expect(Tymeslot.HTTPClientMock, :request, 2, fn :get, url, _body, _headers, _opts ->
+        if String.contains?(url, "pageToken=page2") do
+          sync_response([%{"id" => "evt3"}, %{"id" => "evt4"}], %{"nextSyncToken" => "sync_final"})
+        else
+          assert String.contains?(url, "syncToken=sync_old")
+          sync_response([%{"id" => "evt1"}, %{"id" => "evt2"}], %{"nextPageToken" => "page2"})
+        end
+      end)
+
+      assert {:ok, %{events: events, next_sync_token: "sync_final"}} =
+               CalendarAPI.list_events_incremental(integration)
+
+      assert Enum.map(events, & &1["id"]) == ["evt1", "evt2", "evt3", "evt4"]
+    end
+  end
+
   describe "refresh_token/1" do
     test "calls Google token endpoint and returns new tokens" do
       user = insert(:user)


### PR DESCRIPTION
## What does this change?

Fixes a pagination bug in `Tymeslot.Integrations.Calendar.Google.CalendarAPI.list_events_incremental/1` that caused Google Calendar incremental (delta) syncs to silently drop events and never advance the sync token when a delta response spanned more than one page.

**Root cause**: `list_events_incremental/1` only fetched page 1 of a `syncToken` listing and ignored `nextPageToken`. Google's Calendar API only returns `nextSyncToken` (needed to advance the stored sync cursor) on the *final* page of a multi-page response. Whenever a delta spanned more than 250 events (Google's default page size), the persisted sync token was never advanced, and every subsequent periodic sync run re-fetched the exact same stale first page forever — silently dropping every changed/moved/deleted event beyond page 1.

**Production evidence**: a live integration had returned exactly 250 events on every 15-minute sync run for hours, with `nextPageToken` present and `nextSyncToken` absent on the raw API response. After the fix, a single sync fetched 4,465 events (the full accumulated backlog across ~18 pages) and the sync token advanced correctly.

**Fix**: mirrors the pagination loop that `bootstrap_sync/1` in the same file already implements correctly — walks `pageToken` until exhausted, accumulates events, and only persists the `nextSyncToken` from the final page.

**Tests**: 2 new regression tests (single-page pass-through and multi-page accumulation with correct sync-token extraction from the final page only). Full test suite passes (19/19 in the affected test file, 12243/12246 full suite — 3 pre-existing DST-fuzzing/flaky failures confirmed unrelated).

## Checklist

- [x] Commits are signed off with `git commit -s` (required — CI enforces the [DCO](DCO); see [CONTRIBUTING](CONTRIBUTING.md#signing-off-your-commits))
- [x] Tests pass locally (`mix test`), if relevant