### PR TITLE
fix: write through outbound calendar updates to the local event cache

### DIFF
--- a/lib/tymeslot/integrations/calendar/provider_calendar_event_queries.ex
+++ b/lib/tymeslot/integrations/calendar/provider_calendar_event_queries.ex
@@ -319,6 +319,41 @@ defmodule Tymeslot.Integrations.Calendar.ProviderCalendarEventQueries do
     end
   end
 
+  @doc "Fetches a single cached event by integration ID and provider event ID."
+  @spec get_by_provider_event_id(integer(), String.t()) ::
+          {:ok, ProviderCalendarEventSchema.t()} | {:error, :not_found}
+  def get_by_provider_event_id(calendar_integration_id, provider_event_id) do
+    case Repo.get_by(ProviderCalendarEventSchema,
+           calendar_integration_id: calendar_integration_id,
+           provider_event_id: provider_event_id
+         ) do
+      nil -> {:error, :not_found}
+      event -> {:ok, event}
+    end
+  end
+
+  @doc """
+  Writes through the timing/content fields Tymeslot itself just pushed to the
+  provider onto the matching cache row.
+
+  Used by `Tymeslot.Meetings.CalendarEventSync.update/2` after a successful
+  *outbound* push (e.g. a reschedule), so the calendar-view grid — which
+  prefers a linked cache row over the live meeting — doesn't keep showing
+  the pre-update time until the next inbound sync cycle happens to reconcile
+  it. Limited to the handful of fields Tymeslot actually knows it just
+  wrote; everything else on the row (etag, provider_metadata, the offline
+  sync-queue bookkeeping columns, ...) is left untouched for a real inbound
+  sync to reconcile, matching `update_notification_baseline/3`'s narrow
+  targeted-update pattern rather than `upsert_batch/1`'s full-row replace.
+  """
+  @spec update_after_outbound_push(ProviderCalendarEventSchema.t(), map()) ::
+          {:ok, ProviderCalendarEventSchema.t()} | {:error, Changeset.t()}
+  def update_after_outbound_push(%ProviderCalendarEventSchema{} = event, attrs) do
+    event
+    |> Changeset.cast(attrs, [:start_at, :end_at, :summary, :description, :location, :timezone])
+    |> Repo.update()
+  end
+
   @doc """
   Deletes a single event identified by its integration and uid.
 

--- a/lib/tymeslot/meetings/calendar_event_sync.ex
+++ b/lib/tymeslot/meetings/calendar_event_sync.ex
@@ -28,6 +28,8 @@ defmodule Tymeslot.Meetings.CalendarEventSync do
   alias Ecto.UUID
   alias Tymeslot.Infrastructure.Config
   alias Tymeslot.Integrations.Calendar.CalendarEventBuilder
+  alias Tymeslot.Integrations.Calendar.ProviderCalendarEventQueries
+  alias Tymeslot.Integrations.Calendar.SyncBroadcast
   alias Tymeslot.Meetings.MeetingQueries
   alias Tymeslot.Meetings.MeetingState
   require Logger
@@ -177,11 +179,13 @@ defmodule Tymeslot.Meetings.CalendarEventSync do
     case calendar_module().update_event(calendar_event_identifier(meeting), event_data, meeting) do
       :ok ->
         Logger.info("Calendar event updated successfully", meeting_id: meeting.id)
+        sync_cache_after_outbound_update(meeting, event_data)
         :ok
 
       {:ok, _result} ->
         # Backward/forward compatibility if update returns tagged tuple
         Logger.info("Calendar event updated successfully", meeting_id: meeting.id)
+        sync_cache_after_outbound_update(meeting, event_data)
         :ok
 
       {:error, :not_found} ->
@@ -190,6 +194,67 @@ defmodule Tymeslot.Meetings.CalendarEventSync do
       error ->
         error
     end
+  end
+
+  # Write-through for the outbound push above: keeps the local
+  # `provider_calendar_event` cache row (and any live calendar-grid viewers
+  # subscribed via PubSub) in sync with a Tymeslot-initiated change, instead
+  # of waiting on the next inbound sync cycle to notice the drift. Mirrors
+  # what `Tymeslot.Integrations.Calendar.Sync.post_commit_reconciliation/2`
+  # does for the inbound direction.
+  #
+  # Never fails the update: a successful provider push must not be undone or
+  # retried just because the local cache write-through hiccups — the next
+  # inbound sync is the backstop either way.
+  defp sync_cache_after_outbound_update(meeting, event_data) do
+    with {:ok, cached_event} <- find_cached_event(meeting),
+         {:ok, _updated} <- update_cached_event(cached_event, event_data) do
+      SyncBroadcast.broadcast_cache_update(meeting.organizer_user_id, [cached_event.uid])
+    else
+      {:error, :not_found} ->
+        # No cache row yet — e.g. this is the very first outbound push and no
+        # inbound sync has cached the event. Nothing stale to correct.
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Failed to write through outbound calendar update to local cache",
+          meeting_id: meeting.id,
+          reason: inspect(reason)
+        )
+
+        :ok
+    end
+  end
+
+  # Mirrors the provider_event_id-first, uid-fallback lookup that
+  # `Tymeslot.Meetings.ExternalCalendarChanges.find_linked_meeting/3` already
+  # uses for the inbound direction: OAuth providers (Google, Outlook) key the
+  # cache row by their native `provider_event_id`, while CalDAV never
+  # persists one onto the meeting and instead round-trips the same value in
+  # both `meeting.uid` and the cache row's `uid`.
+  defp find_cached_event(%{provider_event_id: provider_event_id} = meeting)
+       when is_binary(provider_event_id) and byte_size(provider_event_id) > 0 do
+    ProviderCalendarEventQueries.get_by_provider_event_id(
+      meeting.calendar_integration_id,
+      provider_event_id
+    )
+  end
+
+  defp find_cached_event(meeting) do
+    ProviderCalendarEventQueries.get_by_uid(meeting.calendar_integration_id, meeting.uid)
+  end
+
+  defp update_cached_event(cached_event, event_data) do
+    attrs = %{
+      start_at: event_data.start_time,
+      end_at: event_data.end_time,
+      summary: event_data.summary,
+      description: event_data.description,
+      location: event_data.location,
+      timezone: event_data.timezone
+    }
+
+    ProviderCalendarEventQueries.update_after_outbound_push(cached_event, attrs)
   end
 
   defp handle_missing_event(meeting_id, event_data, meeting) do

--- a/test/tymeslot/meetings/calendar_event_sync_test.exs
+++ b/test/tymeslot/meetings/calendar_event_sync_test.exs
@@ -10,6 +10,7 @@ defmodule Tymeslot.Meetings.CalendarEventSyncTest do
 
   alias Ecto.UUID
   alias Tymeslot.Bookings.Orchestrator
+  alias Tymeslot.Integrations.Calendar.ProviderCalendarEventQueries
   alias Tymeslot.Integrations.Calendar.Sync
   alias Tymeslot.Meetings.CalendarEventSync
   alias Tymeslot.Meetings.MeetingQueries
@@ -142,6 +143,126 @@ defmodule Tymeslot.Meetings.CalendarEventSyncTest do
 
     test "returns {:error, :meeting_not_found} for a non-existent meeting" do
       assert {:error, :meeting_not_found} = CalendarEventSync.update(UUID.generate(), 1)
+    end
+  end
+
+  describe "update/2 cache write-through (reschedule cache staleness fix)" do
+    test "writes the new time through to the linked CalDAV cache row and broadcasts it" do
+      %{integration: integration, meeting: meeting} = setup_calendar_scenario()
+
+      stale_start = DateTime.add(meeting.start_time, -3600, :second)
+      stale_end = DateTime.add(meeting.end_time, -3600, :second)
+
+      cached =
+        insert(:provider_calendar_event,
+          calendar_integration: integration,
+          provider: "caldav",
+          uid: meeting.uid,
+          provider_event_id: nil,
+          summary: "Old title",
+          start_at: stale_start,
+          end_at: stale_end
+        )
+
+      Phoenix.PubSub.subscribe(Tymeslot.PubSub, "calendar_events:#{meeting.organizer_user_id}")
+
+      expect_calendar_update_success()
+
+      assert :ok = CalendarEventSync.update(meeting.id, 1)
+
+      reloaded = Repo.get!(cached.__struct__, cached.id)
+      assert DateTime.compare(reloaded.start_at, meeting.start_time) == :eq
+      assert DateTime.compare(reloaded.end_at, meeting.end_time) == :eq
+      assert reloaded.summary == meeting.title
+
+      assert_receive {:calendar_events_updated, user_id, uids}
+      assert user_id == meeting.organizer_user_id
+      assert meeting.uid in uids
+    end
+
+    test "writes through by provider_event_id for OAuth-linked meetings, not uid" do
+      provider_event_id = "google-event-reschedule"
+
+      %{integration: integration, meeting: meeting} =
+        setup_calendar_scenario(uid: UUID.generate())
+
+      {:ok, meeting} =
+        MeetingQueries.update_meeting(meeting, %{provider_event_id: provider_event_id})
+
+      # The cache row's own `uid` is the provider's iCalUID, which is a
+      # different value than the Tymeslot-generated `meeting.uid` for OAuth
+      # providers — only `provider_event_id` links the two.
+      cached =
+        insert(:provider_calendar_event,
+          calendar_integration: integration,
+          provider: "google",
+          uid: "google-ical-uid-different-from-meeting-uid",
+          provider_event_id: provider_event_id,
+          start_at: DateTime.add(meeting.start_time, -3600, :second),
+          end_at: DateTime.add(meeting.end_time, -3600, :second)
+        )
+
+      Phoenix.PubSub.subscribe(Tymeslot.PubSub, "calendar_events:#{meeting.organizer_user_id}")
+
+      expect(Tymeslot.CalendarMock, :update_event, fn ^provider_event_id, _data, _ctx -> :ok end)
+
+      assert :ok = CalendarEventSync.update(meeting.id, 1)
+
+      reloaded = Repo.get!(cached.__struct__, cached.id)
+      assert DateTime.compare(reloaded.start_at, meeting.start_time) == :eq
+      assert DateTime.compare(reloaded.end_at, meeting.end_time) == :eq
+
+      assert_receive {:calendar_events_updated, _user_id, uids}
+      assert cached.uid in uids
+    end
+
+    test "is a no-op when no cache row exists yet (first outbound push before any inbound sync)" do
+      %{meeting: meeting} = setup_calendar_scenario()
+
+      Phoenix.PubSub.subscribe(Tymeslot.PubSub, "calendar_events:#{meeting.organizer_user_id}")
+
+      expect_calendar_update_success()
+
+      assert :ok = CalendarEventSync.update(meeting.id, 1)
+
+      assert {:error, :not_found} =
+               ProviderCalendarEventQueries.get_by_uid(
+                 meeting.calendar_integration_id,
+                 meeting.uid
+               )
+
+      refute_receive {:calendar_events_updated, _, _}, 100
+    end
+
+    test "does not write through the cache when the outbound push fails" do
+      %{integration: integration, meeting: meeting} = setup_calendar_scenario()
+
+      stale_start = DateTime.add(meeting.start_time, -3600, :second)
+      stale_end = DateTime.add(meeting.end_time, -3600, :second)
+
+      cached =
+        insert(:provider_calendar_event,
+          calendar_integration: integration,
+          provider: "caldav",
+          uid: meeting.uid,
+          provider_event_id: nil,
+          start_at: stale_start,
+          end_at: stale_end
+        )
+
+      Phoenix.PubSub.subscribe(Tymeslot.PubSub, "calendar_events:#{meeting.organizer_user_id}")
+
+      expect(Tymeslot.CalendarMock, :update_event, fn _uid, _data, _ctx ->
+        {:error, :connection_failed}
+      end)
+
+      assert {:error, :connection_failed} = CalendarEventSync.update(meeting.id, 1)
+
+      reloaded = Repo.get!(cached.__struct__, cached.id)
+      assert DateTime.compare(reloaded.start_at, stale_start) == :eq
+      assert DateTime.compare(reloaded.end_at, stale_end) == :eq
+
+      refute_receive {:calendar_events_updated, _, _}, 100
     end
   end
 


### PR DESCRIPTION
## What does this change?

Rescheduling a meeting pushes the new time to the external calendar provider (CalDAV/Google/Outlook) synchronously — availability checks are always correct — but this outbound path never updated the local `provider_calendar_event` cache table or broadcast a cache-update event, unlike the inbound sync path, which does both.

Since the calendar-view dedup logic prefers the cache row over the live `Meeting` whenever the two are linked, the calendar grid kept showing the pre-reschedule time until the next inbound sync cycle happened to reconcile it (15-90 minutes later, whenever that provider's poll/webhook next fired).

`CalendarEventSync.update/2` now, after a successful outbound push:
- looks up the linked cache row by `provider_event_id` for OAuth providers, falling back to `uid` for CalDAV — mirroring `ExternalCalendarChanges.find_linked_meeting/3`'s existing lookup order
- writes through the pushed start/end time and content fields via a new narrow `ProviderCalendarEventQueries.update_after_outbound_push/2`
- broadcasts the change the same way inbound sync already does

A failed outbound push never touches the cache, and a missing cache row (e.g. the first outbound push before any inbound sync has run yet) is a no-op.

Covered by 4 new tests: CalDAV write-through, OAuth `provider_event_id`-keyed write-through, no-op when there's no cache row, and no write on push failure.

## Checklist

- [x] Commits are signed off with `git commit -s` (required — CI enforces the [DCO](DCO); see [CONTRIBUTING](CONTRIBUTING.md#signing-off-your-commits))
- [x] Tests pass locally (`mix test`), if relevant